### PR TITLE
Auth: JWT registration and login

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import { connectDB } from './utils/db';
 import { errorHandler } from './middleware/errorHandler';
 import healthRouter from './routes/health';
+import authRouter from './routes/auth';
 
 dotenv.config();
 
@@ -15,6 +16,7 @@ app.use(express.json());
 
 // Routes
 app.use('/health', healthRouter);
+app.use('/auth', authRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthRequest extends Request {
+  userId?: string;
+}
+
+export const authenticate = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): void => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ success: false, data: null, error: 'Unauthorized' });
+    return;
+  }
+
+  const token = authHeader.split(' ')[1];
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    res.status(500).json({ success: false, data: null, error: 'Server misconfiguration' });
+    return;
+  }
+
+  try {
+    const payload = jwt.verify(token, secret) as { userId: string };
+    req.userId = payload.userId;
+    next();
+  } catch {
+    res.status(401).json({ success: false, data: null, error: 'Invalid or expired token' });
+  }
+};

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,0 +1,27 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export interface IUser extends Document {
+  email: string;
+  passwordHash: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const UserSchema = new Schema<IUser>(
+  {
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+    },
+    passwordHash: {
+      type: String,
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+export const User = mongoose.model<IUser>('User', UserSchema);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,73 @@
+import { Router, Request, Response } from 'express';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { User } from '../models/User';
+
+const router = Router();
+const SALT_ROUNDS = 12;
+
+// POST /auth/register
+router.post('/register', async (req: Request, res: Response): Promise<void> => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    res.status(400).json({ success: false, data: null, error: 'Email and password are required' });
+    return;
+  }
+
+  if (password.length < 8) {
+    res.status(400).json({ success: false, data: null, error: 'Password must be at least 8 characters' });
+    return;
+  }
+
+  const existing = await User.findOne({ email: email.toLowerCase() });
+  if (existing) {
+    res.status(409).json({ success: false, data: null, error: 'Email already registered' });
+    return;
+  }
+
+  const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+  const user = await User.create({ email: email.toLowerCase(), passwordHash });
+
+  const secret = process.env.JWT_SECRET!;
+  const token = jwt.sign({ userId: user._id.toString() }, secret, { expiresIn: '30d' });
+
+  res.status(201).json({
+    success: true,
+    data: { token, userId: user._id, email: user.email },
+    error: null,
+  });
+});
+
+// POST /auth/login
+router.post('/login', async (req: Request, res: Response): Promise<void> => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    res.status(400).json({ success: false, data: null, error: 'Email and password are required' });
+    return;
+  }
+
+  const user = await User.findOne({ email: email.toLowerCase() });
+  if (!user) {
+    res.status(401).json({ success: false, data: null, error: 'Invalid credentials' });
+    return;
+  }
+
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) {
+    res.status(401).json({ success: false, data: null, error: 'Invalid credentials' });
+    return;
+  }
+
+  const secret = process.env.JWT_SECRET!;
+  const token = jwt.sign({ userId: user._id.toString() }, secret, { expiresIn: '30d' });
+
+  res.json({
+    success: true,
+    data: { token, userId: user._id, email: user.email },
+    error: null,
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- User model with email + bcrypt password hash
- POST /auth/register — creates user, returns JWT (30d expiry)
- POST /auth/login — validates credentials, returns JWT
- authenticate middleware — verifies Bearer token, 401 on failure

## Test plan
- [x] npx tsc --noEmit — zero errors
- [ ] Register with email + password → receives JWT
- [ ] Login → receives JWT
- [ ] Protected route without token → 401

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)