### PR TITLE
feat(profile): Health Profile API with partial updates and change history

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { connectDB } from './utils/db';
 import { errorHandler } from './middleware/errorHandler';
 import healthRouter from './routes/health';
 import authRouter from './routes/auth';
+import profileRouter from './routes/profile';
 
 dotenv.config();
 
@@ -17,6 +18,7 @@ app.use(express.json());
 // Routes
 app.use('/health', healthRouter);
 app.use('/auth', authRouter);
+app.use('/profile', profileRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/models/HealthProfile.ts
+++ b/src/models/HealthProfile.ts
@@ -1,0 +1,153 @@
+import mongoose, { Document, Schema, Types } from 'mongoose';
+
+// ─── Sub-document interfaces ───────────────────────────────────────────────
+
+export interface IBody {
+  height?: number; // cm
+  weight?: number; // kg
+  age?: number;
+  sex?: 'male' | 'female' | 'other' | 'prefer_not_to_say';
+  bodyCompositionGoals?: string;
+}
+
+export interface IDiet {
+  preferences?: string[];
+  allergies?: string[];
+  intolerances?: string[];
+  dietType?: string; // e.g. 'vegan', 'keto', 'mediterranean'
+}
+
+export interface IExercise {
+  type?: string[]; // e.g. ['running', 'weightlifting']
+  frequency?: string; // e.g. '3x per week'
+  intensity?: 'low' | 'moderate' | 'high';
+  goals?: string[];
+}
+
+export interface ISleep {
+  schedule?: string; // e.g. '11pm–7am'
+  quality?: 'poor' | 'fair' | 'good' | 'excellent';
+  issues?: string[]; // e.g. ['insomnia', 'snoring']
+}
+
+export interface ILifestyle {
+  stressLevel?: 'low' | 'moderate' | 'high' | 'very_high';
+  workType?: 'sedentary' | 'light' | 'moderate' | 'active'; // physical demand of job
+  alcohol?: 'none' | 'occasional' | 'moderate' | 'heavy';
+  smoking?: 'never' | 'former' | 'current';
+}
+
+export interface IGoals {
+  primary?: string[];
+}
+
+// ─── Change history entry ──────────────────────────────────────────────────
+
+export interface IChangeEntry {
+  field: string;
+  oldValue: unknown;
+  newValue: unknown;
+  source: 'user_input';
+  timestamp: Date;
+}
+
+// ─── Root document ─────────────────────────────────────────────────────────
+
+export interface IHealthProfile extends Document {
+  userId: Types.ObjectId;
+  body: IBody;
+  diet: IDiet;
+  exercise: IExercise;
+  sleep: ISleep;
+  lifestyle: ILifestyle;
+  goals: IGoals;
+  changeHistory: IChangeEntry[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// ─── Schemas ───────────────────────────────────────────────────────────────
+
+const BodySchema = new Schema<IBody>(
+  {
+    height: { type: Number },
+    weight: { type: Number },
+    age: { type: Number },
+    sex: { type: String, enum: ['male', 'female', 'other', 'prefer_not_to_say'] },
+    bodyCompositionGoals: { type: String },
+  },
+  { _id: false }
+);
+
+const DietSchema = new Schema<IDiet>(
+  {
+    preferences: [{ type: String }],
+    allergies: [{ type: String }],
+    intolerances: [{ type: String }],
+    dietType: { type: String },
+  },
+  { _id: false }
+);
+
+const ExerciseSchema = new Schema<IExercise>(
+  {
+    type: [{ type: String }],
+    frequency: { type: String },
+    intensity: { type: String, enum: ['low', 'moderate', 'high'] },
+    goals: [{ type: String }],
+  },
+  { _id: false }
+);
+
+const SleepSchema = new Schema<ISleep>(
+  {
+    schedule: { type: String },
+    quality: { type: String, enum: ['poor', 'fair', 'good', 'excellent'] },
+    issues: [{ type: String }],
+  },
+  { _id: false }
+);
+
+const LifestyleSchema = new Schema<ILifestyle>(
+  {
+    stressLevel: { type: String, enum: ['low', 'moderate', 'high', 'very_high'] },
+    workType: { type: String, enum: ['sedentary', 'light', 'moderate', 'active'] },
+    alcohol: { type: String, enum: ['none', 'occasional', 'moderate', 'heavy'] },
+    smoking: { type: String, enum: ['never', 'former', 'current'] },
+  },
+  { _id: false }
+);
+
+const GoalsSchema = new Schema<IGoals>(
+  {
+    primary: [{ type: String }],
+  },
+  { _id: false }
+);
+
+const ChangeEntrySchema = new Schema<IChangeEntry>(
+  {
+    field: { type: String, required: true },
+    oldValue: { type: Schema.Types.Mixed },
+    newValue: { type: Schema.Types.Mixed },
+    source: { type: String, enum: ['user_input'], default: 'user_input', required: true },
+    timestamp: { type: Date, default: Date.now, required: true },
+  },
+  { _id: false }
+);
+
+const HealthProfileSchema = new Schema<IHealthProfile>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true, unique: true, index: true },
+    body: { type: BodySchema, default: () => ({}) },
+    diet: { type: DietSchema, default: () => ({}) },
+    exercise: { type: ExerciseSchema, default: () => ({}) },
+    sleep: { type: SleepSchema, default: () => ({}) },
+    lifestyle: { type: LifestyleSchema, default: () => ({}) },
+    goals: { type: GoalsSchema, default: () => ({}) },
+    changeHistory: { type: [ChangeEntrySchema], default: [] },
+  },
+  { timestamps: true }
+);
+
+export const HealthProfile = mongoose.model<IHealthProfile>('HealthProfile', HealthProfileSchema);

--- a/src/routes/profile.ts
+++ b/src/routes/profile.ts
@@ -1,0 +1,181 @@
+import { Router, Response } from 'express';
+import { Types } from 'mongoose';
+import { authenticate, AuthRequest } from '../middleware/auth';
+import { HealthProfile, IChangeEntry } from '../models/HealthProfile';
+
+const router = Router();
+
+// All routes in this file are protected — authenticate is applied at mount time
+// in index.ts, so we re-declare it here only for the inline router usage.
+// The router itself is exported and mounted with authenticate already applied.
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Flatten a nested object into dot-notation keys.
+ * e.g. { body: { height: 180 } } → { 'body.height': 180 }
+ */
+function flattenObject(
+  obj: Record<string, unknown>,
+  prefix = ''
+): Record<string, unknown> {
+  return Object.entries(obj).reduce<Record<string, unknown>>((acc, [key, value]) => {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      !(value instanceof Date)
+    ) {
+      Object.assign(acc, flattenObject(value as Record<string, unknown>, fullKey));
+    } else {
+      acc[fullKey] = value;
+    }
+    return acc;
+  }, {});
+}
+
+/**
+ * Build a set of IChangeEntry items by comparing old flat values with new flat values.
+ */
+function buildChangeEntries(
+  oldFlat: Record<string, unknown>,
+  newFlat: Record<string, unknown>
+): IChangeEntry[] {
+  const now = new Date();
+  const entries: IChangeEntry[] = [];
+
+  for (const [field, newValue] of Object.entries(newFlat)) {
+    const oldValue = oldFlat[field] ?? null;
+    const serialisedOld = JSON.stringify(oldValue);
+    const serialisedNew = JSON.stringify(newValue);
+    if (serialisedOld !== serialisedNew) {
+      entries.push({ field, oldValue, newValue, source: 'user_input', timestamp: now });
+    }
+  }
+
+  return entries;
+}
+
+// ─── GET /profile ──────────────────────────────────────────────────────────
+
+router.get('/', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = new Types.ObjectId(req.userId);
+
+  const profile = await HealthProfile.findOne({ userId });
+
+  if (!profile) {
+    // Return an empty profile shell — new user, no data yet
+    res.json({
+      success: true,
+      data: {
+        userId,
+        body: {},
+        diet: {},
+        exercise: {},
+        sleep: {},
+        lifestyle: {},
+        goals: {},
+        changeHistory: [],
+      },
+      error: null,
+    });
+    return;
+  }
+
+  res.json({ success: true, data: profile, error: null });
+});
+
+// ─── PUT /profile ──────────────────────────────────────────────────────────
+
+router.put('/', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = new Types.ObjectId(req.userId);
+
+  // Only accept recognised top-level category keys
+  const ALLOWED_CATEGORIES = ['body', 'diet', 'exercise', 'sleep', 'lifestyle', 'goals'] as const;
+  type Category = typeof ALLOWED_CATEGORIES[number];
+
+  const incoming = req.body as Partial<Record<Category, Record<string, unknown>>>;
+
+  // Validate: only known categories accepted
+  const unknownKeys = Object.keys(incoming).filter(
+    (k) => !ALLOWED_CATEGORIES.includes(k as Category)
+  );
+  if (unknownKeys.length > 0) {
+    res.status(400).json({
+      success: false,
+      data: null,
+      error: `Unknown fields: ${unknownKeys.join(', ')}`,
+    });
+    return;
+  }
+
+  // Load or initialise the profile
+  let profile = await HealthProfile.findOne({ userId });
+  const isNew = !profile;
+
+  if (!profile) {
+    profile = new HealthProfile({ userId });
+  }
+
+  // Capture old flat values for change tracking
+  const oldFlat = flattenObject(
+    ALLOWED_CATEGORIES.reduce<Record<string, unknown>>((acc, cat) => {
+      const val = (profile as unknown as Record<string, unknown>)[cat];
+      if (val && typeof val === 'object') {
+        acc[cat] = (val as { toObject?: () => unknown }).toObject
+          ? (val as { toObject: () => unknown }).toObject()
+          : val;
+      } else {
+        acc[cat] = {};
+      }
+      return acc;
+    }, {})
+  );
+
+  // Apply partial updates using dot-notation $set to avoid overwriting sibling fields
+  const setPayload: Record<string, unknown> = {};
+
+  for (const cat of ALLOWED_CATEGORIES) {
+    if (!(cat in incoming)) continue;
+    const categoryData = incoming[cat];
+    if (typeof categoryData !== 'object' || categoryData === null || Array.isArray(categoryData)) {
+      res.status(400).json({
+        success: false,
+        data: null,
+        error: `Field '${cat}' must be an object`,
+      });
+      return;
+    }
+    for (const [field, value] of Object.entries(categoryData)) {
+      setPayload[`${cat}.${field}`] = value;
+    }
+  }
+
+  // Build new flat snapshot for change detection
+  // Merge incoming fields onto the captured old values
+  const mergedFlat: Record<string, unknown> = { ...oldFlat };
+  for (const [dotKey, value] of Object.entries(setPayload)) {
+    mergedFlat[dotKey] = value;
+  }
+
+  const newEntries = isNew
+    ? buildChangeEntries({}, mergedFlat)
+    : buildChangeEntries(oldFlat, mergedFlat);
+
+  // Persist using findOneAndUpdate with $set + $push for history
+  const updateOp: Record<string, unknown> = { $set: setPayload };
+  if (newEntries.length > 0) {
+    updateOp['$push'] = { changeHistory: { $each: newEntries } };
+  }
+
+  const updated = await HealthProfile.findOneAndUpdate(
+    { userId },
+    updateOp,
+    { new: true, upsert: true, setDefaultsOnInsert: true }
+  );
+
+  res.json({ success: true, data: updated, error: null });
+});
+
+export default router;


### PR DESCRIPTION
## What
- `src/models/HealthProfile.ts` — Mongoose model with six profile categories (body, diet, exercise, sleep, lifestyle, goals) and embedded change history
- `src/routes/profile.ts` — GET /profile + PUT /profile, both JWT-protected
- `src/index.ts` — mounts the profile router at /profile

## Why
Closes #3

## Acceptance Criteria
- [x] GET /profile returns complete profile (empty shell for new users, no 404)
- [x] PUT /profile supports partial updates — only fields sent are updated; dot-notation $set never overwrites sibling fields
- [x] All fields optional — profile starts empty for new users
- [x] Change history recorded per field: `{ field, oldValue, newValue, source: 'user_input', timestamp }`
- [x] `npx tsc --noEmit` passes — zero TypeScript errors

## Key design decisions
- `authenticate` is applied per-route inside the router (inline) so the router is self-contained; index.ts just mounts it at `/profile`
- Partial update uses `findOneAndUpdate` with dot-notation `$set` payload (e.g. `body.height`) — this is the correct MongoDB approach to avoid overwriting sibling fields within a category
- Change detection flattens both old and new state to dot-notation, then diffs by JSON-serialised value — handles arrays and nested objects correctly
- GET returns an empty profile shell (not 404) when no profile exists yet — cleaner for mobile clients on first load
- `userId` field has a unique index — enforces one profile per user at the DB layer

## Test Plan
1. Register a user via POST /auth/register → get token
2. GET /profile → expect `{ success: true, data: { body: {}, diet: {}, ... } }`
3. PUT /profile with `{ "body": { "height": 180, "weight": 75 } }` → expect updated profile with changeHistory entries
4. GET /profile again → confirm height/weight persisted
5. PUT /profile with `{ "diet": { "dietType": "vegan" } }` → confirm body fields untouched, only dietType added to history
6. PUT /profile with unknown key → expect 400 error