### PR TITLE
feat: Supplement Cabinet API (#4)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { connectDB } from './utils/db';
 import { errorHandler } from './middleware/errorHandler';
 import healthRouter from './routes/health';
 import authRouter from './routes/auth';
+import cabinetRouter from './routes/cabinet';
+import { authenticate } from './middleware/auth';
 
 dotenv.config();
 
@@ -17,6 +19,7 @@ app.use(express.json());
 // Routes
 app.use('/health', healthRouter);
 app.use('/auth', authRouter);
+app.use('/cabinet', authenticate, cabinetRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/models/CabinetItem.ts
+++ b/src/models/CabinetItem.ts
@@ -1,0 +1,81 @@
+import mongoose, { Document, Schema, Types } from 'mongoose';
+
+export type CabinetItemType = 'supplement' | 'medication' | 'vitamin';
+export type CabinetItemSource = 'user_input' | 'ai_extracted';
+
+export interface ICabinetItem extends Document {
+  userId: Types.ObjectId;
+  name: string;
+  type: CabinetItemType;
+  dosage?: string;
+  frequency?: string;
+  timing?: string;
+  brand?: string;
+  notes?: string;
+  active: boolean;
+  startDate: Date;
+  endDate?: Date;
+  source: CabinetItemSource;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const CabinetItemSchema = new Schema<ICabinetItem>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    type: {
+      type: String,
+      enum: ['supplement', 'medication', 'vitamin'],
+      required: true,
+    },
+    dosage: {
+      type: String,
+      trim: true,
+    },
+    frequency: {
+      type: String,
+      trim: true,
+    },
+    timing: {
+      type: String,
+      trim: true,
+    },
+    brand: {
+      type: String,
+      trim: true,
+    },
+    notes: {
+      type: String,
+      trim: true,
+    },
+    active: {
+      type: Boolean,
+      default: true,
+    },
+    startDate: {
+      type: Date,
+      default: () => new Date(),
+    },
+    endDate: {
+      type: Date,
+    },
+    source: {
+      type: String,
+      enum: ['user_input', 'ai_extracted'],
+      default: 'user_input',
+    },
+  },
+  { timestamps: true }
+);
+
+export const CabinetItem = mongoose.model<ICabinetItem>('CabinetItem', CabinetItemSchema);

--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -1,0 +1,180 @@
+import { Router, Response } from 'express';
+import mongoose from 'mongoose';
+import { AuthRequest } from '../middleware/auth';
+import { CabinetItem, CabinetItemType } from '../models/CabinetItem';
+
+const router = Router();
+
+// POST /cabinet — add item
+router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const { name, type, dosage, frequency, timing, brand, notes, active, startDate, endDate, source } = req.body;
+
+  if (!name || typeof name !== 'string' || name.trim() === '') {
+    res.status(400).json({ success: false, data: null, error: 'name is required' });
+    return;
+  }
+
+  const validTypes: CabinetItemType[] = ['supplement', 'medication', 'vitamin'];
+  if (!type || !validTypes.includes(type)) {
+    res.status(400).json({ success: false, data: null, error: 'type must be one of: supplement, medication, vitamin' });
+    return;
+  }
+
+  const item = await CabinetItem.create({
+    userId: req.userId,
+    name: name.trim(),
+    type,
+    dosage,
+    frequency,
+    timing,
+    brand,
+    notes,
+    active: active !== undefined ? active : true,
+    startDate: startDate ? new Date(startDate) : new Date(),
+    endDate: endDate ? new Date(endDate) : undefined,
+    source: source || 'user_input',
+  });
+
+  res.status(201).json({
+    success: true,
+    data: { ...item.toObject(), interactions: [] },
+    error: null,
+  });
+});
+
+// GET /cabinet — list user's items with optional filters
+router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const query: Record<string, unknown> = { userId: req.userId };
+
+  const validTypes: CabinetItemType[] = ['supplement', 'medication', 'vitamin'];
+  if (req.query.type) {
+    const typeParam = req.query.type as string;
+    if (!validTypes.includes(typeParam as CabinetItemType)) {
+      res.status(400).json({ success: false, data: null, error: 'type must be one of: supplement, medication, vitamin' });
+      return;
+    }
+    query.type = typeParam;
+  }
+
+  if (req.query.active !== undefined) {
+    if (req.query.active === 'true') {
+      query.active = true;
+    } else if (req.query.active === 'false') {
+      query.active = false;
+    } else {
+      res.status(400).json({ success: false, data: null, error: 'active must be true or false' });
+      return;
+    }
+  }
+
+  const items = await CabinetItem.find(query).sort({ createdAt: -1 });
+
+  res.json({
+    success: true,
+    data: items,
+    error: null,
+  });
+});
+
+// PUT /cabinet/:id — update item (PATCH semantics, owner only)
+router.put('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
+  const id = req.params['id'] as string;
+
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    res.status(400).json({ success: false, data: null, error: 'Invalid item id' });
+    return;
+  }
+
+  const item = await CabinetItem.findById(id);
+  if (!item) {
+    res.status(404).json({ success: false, data: null, error: 'Item not found' });
+    return;
+  }
+
+  if (item.userId.toString() !== req.userId) {
+    res.status(403).json({ success: false, data: null, error: 'Forbidden' });
+    return;
+  }
+
+  const allowedFields = ['name', 'type', 'dosage', 'frequency', 'timing', 'brand', 'notes', 'active', 'startDate', 'endDate', 'source'] as const;
+  type AllowedField = typeof allowedFields[number];
+
+  const validTypes: CabinetItemType[] = ['supplement', 'medication', 'vitamin'];
+  const updates: Partial<Record<AllowedField, unknown>> = {};
+
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      if (field === 'type' && !validTypes.includes(req.body[field])) {
+        res.status(400).json({ success: false, data: null, error: 'type must be one of: supplement, medication, vitamin' });
+        return;
+      }
+      if (field === 'source' && !['user_input', 'ai_extracted'].includes(req.body[field])) {
+        res.status(400).json({ success: false, data: null, error: 'source must be one of: user_input, ai_extracted' });
+        return;
+      }
+      if (field === 'name' && (typeof req.body[field] !== 'string' || req.body[field].trim() === '')) {
+        res.status(400).json({ success: false, data: null, error: 'name cannot be empty' });
+        return;
+      }
+      if ((field === 'startDate' || field === 'endDate') && req.body[field] !== null) {
+        updates[field] = new Date(req.body[field] as string);
+      } else {
+        updates[field] = req.body[field];
+      }
+    }
+  }
+
+  const updated = await CabinetItem.findByIdAndUpdate(id, { $set: updates }, { new: true, runValidators: true });
+
+  res.json({
+    success: true,
+    data: { ...updated!.toObject(), interactions: [] },
+    error: null,
+  });
+});
+
+// DELETE /cabinet/:id — soft delete (set active=false + endDate=now)
+router.delete('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
+  const id = req.params['id'] as string;
+
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    res.status(400).json({ success: false, data: null, error: 'Invalid item id' });
+    return;
+  }
+
+  const item = await CabinetItem.findById(id);
+  if (!item) {
+    res.status(404).json({ success: false, data: null, error: 'Item not found' });
+    return;
+  }
+
+  if (item.userId.toString() !== req.userId) {
+    res.status(403).json({ success: false, data: null, error: 'Forbidden' });
+    return;
+  }
+
+  // Soft delete: archive the item
+  const hardDelete = req.query.hard === 'true';
+
+  if (hardDelete) {
+    await CabinetItem.findByIdAndDelete(id);
+    res.json({
+      success: true,
+      data: { deleted: true, id },
+      error: null,
+    });
+  } else {
+    const archived = await CabinetItem.findByIdAndUpdate(
+      id,
+      { $set: { active: false, endDate: new Date() } },
+      { new: true }
+    );
+    res.json({
+      success: true,
+      data: archived,
+      error: null,
+    });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## What
Implements full CRUD for the supplement/medication cabinet.

**New files:**
- `src/models/CabinetItem.ts` — Mongoose schema with all fields (userId, name, type, dosage, frequency, timing, brand, notes, active, startDate, endDate, source)
- `src/routes/cabinet.ts` — 4 endpoints (POST, GET, PUT, DELETE)

**Modified:**
- `src/index.ts` — mounts `/cabinet` route with `authenticate` middleware

## Why
Closes #4

## Acceptance Criteria
- [x] POST /cabinet creates item and returns it with `interactions: []`
- [x] GET /cabinet returns all user's items, filterable by `?type=` and `?active=`
- [x] PUT /cabinet/:id updates only sent fields (PATCH semantics), returns item with `interactions: []`
- [x] DELETE /cabinet/:id soft-deletes (sets `active=false` + `endDate=now`); `?hard=true` for permanent removal
- [x] Ownership check on PUT/DELETE — 403 if userId mismatch
- [x] All queries scoped to `req.userId` — users only see their own items
- [x] `npx tsc --noEmit` passes

## Test Plan
1. Register a user via `POST /auth/register`, copy the token
2. `POST /cabinet` with `{ name: "Vitamin D", type: "vitamin", dosage: "2000IU" }` — expect 201, item returned with `interactions: []`
3. `GET /cabinet` — expect array with the item
4. `GET /cabinet?type=vitamin&active=true` — expect filtered results
5. `PUT /cabinet/:id` with `{ dosage: "4000IU" }` — expect updated item with `interactions: []`
6. `DELETE /cabinet/:id` — expect soft delete (item still in DB with `active: false`)
7. `DELETE /cabinet/:id?hard=true` — expect hard delete (`deleted: true`)
8. Try PUT/DELETE with a different user's token — expect 403

> Note: This PR is based on `feat/auth` (PR #15) which must merge first.