### PR TITLE
feat(chat): AI health chat with Claude, conversation history, and profile extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.87.0",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.6",
         "dotenv": "^17.4.1",
@@ -27,6 +28,35 @@
         "prettier": "^3.8.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^6.0.2"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.87.0.tgz",
+      "integrity": "sha512-ZvBWT5VkPTW6b8LIpugpuAkpcYPSLOXdWTcgQrpUqf4IeJ5ZrH5rT8sTsUDvxPCHAlRG3nF4VIWfjw6uLhJ18g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -1789,6 +1819,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2849,6 +2892,12 @@
       "bin": {
         "tree-kill": "cli.js"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/wkliwk/recallth-backend#readme",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.87.0",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import authRouter from './routes/auth';
 import authGoogleRouter from './routes/authGoogle';
 import profileRouter from './routes/profile';
 import cabinetRouter from './routes/cabinet';
+import chatRouter from './routes/chat';
 import { authenticate } from './middleware/auth';
 
 dotenv.config();
@@ -24,6 +25,7 @@ app.use('/auth', authRouter);
 app.use('/auth', authGoogleRouter);
 app.use('/profile', profileRouter);
 app.use('/cabinet', authenticate, cabinetRouter);
+app.use('/chat', authenticate, chatRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/models/Conversation.ts
+++ b/src/models/Conversation.ts
@@ -1,0 +1,39 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export type MessageRole = 'user' | 'assistant';
+
+export interface IMessage {
+  role: MessageRole;
+  content: string;
+  timestamp: Date;
+}
+
+export interface IConversation extends Document {
+  userId: Types.ObjectId;
+  title: string;
+  messages: IMessage[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const MessageSchema = new Schema<IMessage>(
+  {
+    role: { type: String, enum: ['user', 'assistant'], required: true },
+    content: { type: String, required: true },
+    timestamp: { type: Date, default: Date.now },
+  },
+  { _id: false }
+);
+
+const ConversationSchema = new Schema<IConversation>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    title: { type: String, required: true, default: 'New Conversation' },
+    messages: [MessageSchema],
+  },
+  { timestamps: true }
+);
+
+ConversationSchema.index({ userId: 1, createdAt: -1 });
+
+export const Conversation = model<IConversation>('Conversation', ConversationSchema);

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -1,0 +1,122 @@
+import { Router, Response } from 'express';
+import { Types } from 'mongoose';
+import { authenticate, AuthRequest } from '../middleware/auth';
+import { processChat, checkRateLimit } from '../services/chatService';
+import { Conversation } from '../models/Conversation';
+
+const chatRouter = Router();
+
+// All routes require auth
+chatRouter.use(authenticate);
+
+// POST /chat — send message, get AI response
+chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string;
+  const { message, conversationId } = req.body as {
+    message?: string;
+    conversationId?: string;
+  };
+
+  if (!message || typeof message !== 'string' || message.trim().length === 0) {
+    res.status(400).json({ success: false, error: 'message is required', data: null });
+    return;
+  }
+
+  if (message.trim().length > 4000) {
+    res.status(400).json({ success: false, error: 'message too long (max 4000 characters)', data: null });
+    return;
+  }
+
+  if (conversationId && !Types.ObjectId.isValid(conversationId)) {
+    res.status(400).json({ success: false, error: 'invalid conversationId', data: null });
+    return;
+  }
+
+  // Rate limiting
+  const rateCheck = checkRateLimit(userId);
+  if (!rateCheck.allowed) {
+    res.status(429).json({
+      success: false,
+      error: 'Rate limit exceeded. Maximum 30 messages per hour.',
+      data: {
+        resetAt: new Date(rateCheck.resetAt).toISOString(),
+        remaining: 0,
+      },
+    });
+    return;
+  }
+
+  const result = await processChat(userId, message.trim(), conversationId);
+
+  res.status(200).json({
+    success: true,
+    error: null,
+    data: {
+      conversationId: result.conversationId,
+      message: result.message,
+      extractedData: result.extractedData,
+    },
+  });
+});
+
+// GET /chat/history — list conversations (paginated, 20/page)
+chatRouter.get('/history', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string;
+  const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10));
+  const limit = 20;
+  const skip = (page - 1) * limit;
+
+  const conversations = await Conversation.aggregate([
+    { $match: { userId: new Types.ObjectId(userId) } },
+    { $sort: { createdAt: -1 } },
+    { $skip: skip },
+    { $limit: limit },
+    {
+      $project: {
+        _id: 1,
+        title: 1,
+        createdAt: 1,
+        messageCount: { $size: '$messages' },
+      },
+    },
+  ]);
+
+  res.status(200).json({
+    success: true,
+    error: null,
+    data: {
+      conversations,
+      page,
+      limit,
+    },
+  });
+});
+
+// GET /chat/:conversationId — get full conversation
+chatRouter.get('/:conversationId', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string;
+  const conversationId = String(req.params.conversationId);
+
+  if (!Types.ObjectId.isValid(conversationId)) {
+    res.status(400).json({ success: false, error: 'invalid conversationId', data: null });
+    return;
+  }
+
+  const conversation = await Conversation.findOne({
+    _id: new Types.ObjectId(conversationId),
+    userId: new Types.ObjectId(userId),
+  });
+
+  if (!conversation) {
+    res.status(404).json({ success: false, error: 'Conversation not found', data: null });
+    return;
+  }
+
+  res.status(200).json({
+    success: true,
+    error: null,
+    data: conversation,
+  });
+});
+
+export default chatRouter;

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,0 +1,321 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { Types } from 'mongoose';
+import { HealthProfile, IHealthProfile } from '../models/HealthProfile';
+import { CabinetItem, ICabinetItem } from '../models/CabinetItem';
+import { Conversation } from '../models/Conversation';
+
+const anthropic = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+});
+
+// --- Rate limiting ---
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const rateLimitMap = new Map<string, RateLimitEntry>();
+const RATE_LIMIT_MAX = 30;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+export function checkRateLimit(userId: string): { allowed: boolean; remaining: number; resetAt: number } {
+  const now = Date.now();
+  const entry = rateLimitMap.get(userId);
+
+  if (!entry || now >= entry.resetAt) {
+    const newEntry: RateLimitEntry = { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS };
+    rateLimitMap.set(userId, newEntry);
+    return { allowed: true, remaining: RATE_LIMIT_MAX - 1, resetAt: newEntry.resetAt };
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX) {
+    return { allowed: false, remaining: 0, resetAt: entry.resetAt };
+  }
+
+  entry.count += 1;
+  return { allowed: true, remaining: RATE_LIMIT_MAX - entry.count, resetAt: entry.resetAt };
+}
+
+// --- System prompt builder ---
+function buildSystemPrompt(profile: IHealthProfile | null, cabinetItems: ICabinetItem[]): string {
+  const profileData = profile
+    ? {
+        body: profile.body,
+        diet: profile.diet,
+        exercise: profile.exercise,
+        sleep: profile.sleep,
+        lifestyle: profile.lifestyle,
+        goals: profile.goals,
+      }
+    : null;
+
+  const cabinetData = cabinetItems.map((item) => ({
+    name: item.name,
+    type: item.type,
+    dosage: item.dosage,
+    frequency: item.frequency,
+    timing: item.timing,
+    brand: item.brand,
+  }));
+
+  return `You are Recallth, a personal AI health advisor with perfect memory of this user's health profile.
+
+USER HEALTH PROFILE:
+${JSON.stringify(profileData, null, 2)}
+
+CURRENT SUPPLEMENT & MEDICATION CABINET:
+${JSON.stringify(cabinetData, null, 2)}
+
+INSTRUCTIONS:
+- Always personalise responses using the user's actual data above
+- Reference specific values (e.g. "given your 400mg magnesium intake...")
+- If a profile field is empty/missing, do NOT assume or invent values
+- Support English, Cantonese, and Chinese — respond in the same language the user writes in
+- After EVERY response, append this disclaimer on a new line:
+  "⚠️ This is not medical advice. Consult a healthcare professional for medical decisions."
+- Be warm, helpful, and direct — like a knowledgeable friend, not a clinical report
+- If asked about something outside health/wellness, politely redirect`;
+}
+
+// --- Extraction types ---
+interface ExtractedBody {
+  height?: number | null;
+  weight?: number | null;
+  age?: number | null;
+  sex?: string | null;
+}
+
+interface ExtractedDiet {
+  allergies?: string[] | null;
+  dietType?: string | null;
+}
+
+interface ExtractedExercise {
+  frequency?: string | null;
+  type?: string | null;
+  goals?: string | null;
+}
+
+interface ExtractedSleep {
+  schedule?: string | null;
+  quality?: string | null;
+}
+
+interface ExtractedLifestyle {
+  stressLevel?: string | null;
+  alcohol?: string | null;
+  smoking?: string | null;
+}
+
+interface ExtractedGoals {
+  primary?: string | null;
+}
+
+interface ExtractedCabinetItem {
+  name?: string | null;
+  dosage?: string | null;
+  frequency?: string | null;
+  timing?: string | null;
+  brand?: string | null;
+}
+
+interface ExtractionResult {
+  body?: ExtractedBody;
+  diet?: ExtractedDiet;
+  exercise?: ExtractedExercise;
+  sleep?: ExtractedSleep;
+  lifestyle?: ExtractedLifestyle;
+  goals?: ExtractedGoals;
+  cabinetItems?: ExtractedCabinetItem[];
+}
+
+// --- Profile extraction ---
+async function extractHealthData(userMessage: string): Promise<ExtractionResult | null> {
+  const extractionPrompt = `Extract any health profile data from this user message. Return ONLY valid JSON or null.
+
+User message: ${userMessage}
+
+Extract these fields if mentioned (use null for anything not mentioned):
+{
+  "body": { "height": null, "weight": null, "age": null, "sex": null },
+  "diet": { "allergies": null, "dietType": null },
+  "exercise": { "frequency": null, "type": null, "goals": null },
+  "sleep": { "schedule": null, "quality": null },
+  "lifestyle": { "stressLevel": null, "alcohol": null, "smoking": null },
+  "goals": { "primary": null },
+  "cabinetItems": [{ "name": null, "dosage": null, "frequency": null, "timing": null, "brand": null }]
+}
+
+Only include fields explicitly stated. Return null if nothing to extract.`;
+
+  const response = await anthropic.messages.create({
+    model: 'claude-opus-4-5',
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: extractionPrompt }],
+  });
+
+  const text = response.content[0].type === 'text' ? response.content[0].text.trim() : '';
+
+  if (!text || text === 'null') return null;
+
+  // Strip markdown code fences if present
+  const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+
+  try {
+    const parsed: ExtractionResult = JSON.parse(cleaned) as ExtractionResult;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// --- Apply extraction to DB ---
+async function applyExtractedData(
+  userId: Types.ObjectId,
+  extracted: ExtractionResult
+): Promise<void> {
+  // Build dot-notation $set for profile fields
+  const profileSet: Record<string, unknown> = { source: 'ai_extracted' };
+
+  const profileCategories: Array<keyof Omit<ExtractionResult, 'cabinetItems'>> = [
+    'body', 'diet', 'exercise', 'sleep', 'lifestyle', 'goals',
+  ];
+
+  for (const category of profileCategories) {
+    const categoryData = extracted[category] as Record<string, unknown> | undefined;
+    if (!categoryData) continue;
+
+    for (const [field, value] of Object.entries(categoryData)) {
+      if (value !== null && value !== undefined) {
+        profileSet[`${category}.${field}`] = value;
+      }
+    }
+  }
+
+  if (Object.keys(profileSet).length > 1) {
+    await HealthProfile.findOneAndUpdate(
+      { userId },
+      { $set: profileSet },
+      { upsert: true, new: true }
+    );
+  }
+
+  // Create cabinet items for any new supplements mentioned
+  if (extracted.cabinetItems && extracted.cabinetItems.length > 0) {
+    for (const item of extracted.cabinetItems) {
+      if (item.name) {
+        await CabinetItem.create({
+          userId,
+          name: item.name,
+          dosage: item.dosage ?? undefined,
+          frequency: item.frequency ?? undefined,
+          timing: item.timing ?? undefined,
+          brand: item.brand ?? undefined,
+          source: 'ai_extracted',
+          active: true,
+        });
+      }
+    }
+  }
+}
+
+// --- Generate title from first message ---
+function generateTitle(message: string): string {
+  const trimmed = message.trim();
+  if (trimmed.length <= 50) return trimmed;
+  return trimmed.slice(0, 47) + '...';
+}
+
+// --- Main chat function ---
+export interface ChatResult {
+  conversationId: string;
+  message: {
+    role: 'assistant';
+    content: string;
+    timestamp: Date;
+  };
+  extractedData: ExtractionResult | null;
+}
+
+export async function processChat(
+  userId: string,
+  userMessage: string,
+  conversationId?: string
+): Promise<ChatResult> {
+  const userObjectId = new Types.ObjectId(userId);
+
+  // Load profile and cabinet in parallel
+  const [profile, cabinetItems] = await Promise.all([
+    HealthProfile.findOne({ userId: userObjectId }),
+    CabinetItem.find({ userId: userObjectId, active: true }),
+  ]);
+
+  // Fetch or create conversation
+  let conversation;
+  if (conversationId) {
+    conversation = await Conversation.findOne({
+      _id: new Types.ObjectId(conversationId),
+      userId: userObjectId,
+    });
+    if (!conversation) {
+      const err = new Error('Conversation not found') as Error & { statusCode: number };
+      err.statusCode = 404;
+      throw err;
+    }
+  } else {
+    conversation = await Conversation.create({
+      userId: userObjectId,
+      title: generateTitle(userMessage),
+      messages: [],
+    });
+  }
+
+  // Append user message
+  const userMsg = { role: 'user' as const, content: userMessage, timestamp: new Date() };
+  conversation.messages.push(userMsg);
+
+  // Build message history for Claude (last 20 messages for context window)
+  const historyForClaude = conversation.messages.slice(-20).map((m) => ({
+    role: m.role as 'user' | 'assistant',
+    content: m.content,
+  }));
+
+  // Call Claude for chat response
+  const systemPrompt = buildSystemPrompt(profile, cabinetItems);
+
+  const chatResponse = await anthropic.messages.create({
+    model: 'claude-opus-4-5',
+    max_tokens: 2048,
+    system: systemPrompt,
+    messages: historyForClaude,
+  });
+
+  const assistantContent =
+    chatResponse.content[0].type === 'text' ? chatResponse.content[0].text : '';
+
+  const assistantMsg = {
+    role: 'assistant' as const,
+    content: assistantContent,
+    timestamp: new Date(),
+  };
+  conversation.messages.push(assistantMsg);
+  await conversation.save();
+
+  // Run extraction in parallel (non-blocking on response, but we await to include in response)
+  let extractedData: ExtractionResult | null = null;
+  try {
+    extractedData = await extractHealthData(userMessage);
+    if (extractedData) {
+      await applyExtractedData(userObjectId, extractedData);
+    }
+  } catch (err) {
+    // Extraction failure should not break the chat response
+    console.error('[Chat] Extraction error:', err);
+  }
+
+  return {
+    conversationId: String(conversation._id),
+    message: assistantMsg,
+    extractedData,
+  };
+}


### PR DESCRIPTION
## What
AI-powered health chat backed by Claude. Every response is personalised using the user's full HealthProfile and active CabinetItems injected into the system prompt. A second Claude call extracts any health data the user mentions in passing and upserts it back to their profile automatically (chat-first profiling).

## Why
Closes #5

## Acceptance Criteria
- [x] POST /chat creates/continues conversation, returns AI response
- [x] System prompt includes full profile + cabinet
- [x] AI responds in same language as user (EN/Cantonese/Chinese) — enforced in system prompt
- [x] Disclaimer appended to every response — enforced in system prompt
- [x] Chat-first extraction runs after each message via second Claude call
- [x] extractedData returned in response when data is extracted
- [x] GET /chat/history returns paginated conversation list with messageCount
- [x] GET /chat/:id returns full conversation
- [x] Rate limit: 30 msg/hour/user → 429 when exceeded
- [x] npx tsc --noEmit passes — zero errors

## New Files
- \`src/models/Conversation.ts\` — Conversation schema with embedded messages array
- \`src/models/HealthProfile.ts\` — HealthProfile schema (matches issue #3 design)
- \`src/models/CabinetItem.ts\` — CabinetItem schema (matches issue #4 design)
- \`src/models/User.ts\` — User schema
- \`src/middleware/auth.ts\` — JWT Bearer auth middleware, exposes AuthRequest + authenticate
- \`src/services/chatService.ts\` — all AI logic: system prompt builder, chat call, extraction call, rate limiter, profile upsert
- \`src/routes/chat.ts\` — POST /chat, GET /chat/history, GET /chat/:id

## Test Plan
1. Register a user via POST /auth/register (once auth route is deployed) and obtain JWT
2. POST /chat with \`{ "message": "I take 400mg magnesium at night" }\` — verify AI response references the supplement and disclaimer is present
3. Check response includes \`extractedData\` with cabinetItems populated
4. POST /chat again with the returned conversationId — verify conversation continues
5. GET /chat/history — verify conversation appears with messageCount
6. GET /chat/:id — verify all messages returned
7. Fire 31 POST /chat requests in the same hour — verify 429 on the 31st

## Notes
- \`ANTHROPIC_API_KEY\` must be set in Railway environment
- Rate limit resets every hour per user; stored in-memory (resets on server restart — acceptable for MVP)