### PR TITLE
feat: interaction checker API (issue #6)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import authGoogleRouter from './routes/authGoogle';
 import profileRouter from './routes/profile';
 import cabinetRouter from './routes/cabinet';
 import chatRouter from './routes/chat';
+import interactionsRouter from './routes/interactions';
 import { authenticate } from './middleware/auth';
 
 dotenv.config();
@@ -25,6 +26,7 @@ app.use('/auth', authRouter);
 app.use('/auth', authGoogleRouter);
 app.use('/profile', profileRouter);
 app.use('/cabinet', authenticate, cabinetRouter);
+app.use('/cabinet/interactions', authenticate, interactionsRouter);
 app.use('/chat', authenticate, chatRouter);
 
 // Error handling

--- a/src/routes/interactions.ts
+++ b/src/routes/interactions.ts
@@ -1,0 +1,36 @@
+import { Router, Response } from 'express';
+import { AuthRequest } from '../middleware/auth';
+import { CabinetItem } from '../models/CabinetItem';
+import { checkCabinetInteractions } from '../services/interactionChecker';
+
+const router = Router();
+
+/**
+ * GET /cabinet/interactions
+ * Check all active cabinet items for pairwise interactions.
+ * Protected: requires valid Bearer JWT (applied at mount point in index.ts).
+ */
+router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId;
+  if (!userId) {
+    res.status(401).json({ success: false, data: null, error: 'Unauthorized' });
+    return;
+  }
+
+  const items = await CabinetItem.find({ userId, active: true }).sort({ createdAt: -1 });
+
+  if (items.length < 2) {
+    res.json({ success: true, data: { interactions: [] }, error: null });
+    return;
+  }
+
+  const interactions = await checkCabinetInteractions(items);
+
+  res.json({
+    success: true,
+    data: { interactions },
+    error: null,
+  });
+});
+
+export default router;

--- a/src/services/interactionChecker.ts
+++ b/src/services/interactionChecker.ts
@@ -1,0 +1,168 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { ICabinetItem } from '../models/CabinetItem';
+
+export interface Interaction {
+  item1: string;
+  item2: string;
+  severity: 'minor' | 'moderate' | 'major';
+  description: string;
+  recommendation: string;
+  citation: string;
+}
+
+interface ClaudeInteractionResponse {
+  interactions: Array<{
+    item1: string;
+    item2: string;
+    severity: string;
+    description: string;
+    recommendation: string;
+    citation: string;
+  }>;
+}
+
+const VALID_SEVERITIES = new Set<string>(['minor', 'moderate', 'major']);
+
+function buildItemList(items: ICabinetItem[]): string {
+  return items
+    .map((item, idx) => {
+      const parts = [`${idx + 1}. ${item.name} (${item.type})`];
+      if (item.dosage) parts.push(`dosage: ${item.dosage}`);
+      if (item.frequency) parts.push(`frequency: ${item.frequency}`);
+      if (item.timing) parts.push(`timing: ${item.timing}`);
+      return parts.join(', ');
+    })
+    .join('\n');
+}
+
+function buildPrompt(items: ICabinetItem[]): string {
+  const itemList = buildItemList(items);
+  return `You are a pharmacology expert checking for interactions between supplements and medications.
+
+Check ALL pairwise interactions between these items:
+${itemList}
+
+For each interaction found, return JSON:
+{
+  "interactions": [
+    {
+      "item1": "Supplement A",
+      "item2": "Supplement B",
+      "severity": "minor|moderate|major",
+      "description": "Plain language explanation of the risk",
+      "recommendation": "What the user should do",
+      "citation": "Source URL (NIH, examine.com, pubmed, drugs.com)"
+    }
+  ]
+}
+
+Rules:
+- Only report interactions with actual evidence — do not guess
+- If no interactions found, return { "interactions": [] }
+- Severity levels: minor (awareness only), moderate (timing adjustment needed), major (avoid combination)
+- Always provide a citation URL
+- Return ONLY valid JSON, no other text`;
+}
+
+function parseClaudeResponse(content: string): Interaction[] {
+  let parsed: ClaudeInteractionResponse;
+  try {
+    parsed = JSON.parse(content) as ClaudeInteractionResponse;
+  } catch {
+    throw new Error(`Claude returned non-JSON response: ${content.slice(0, 200)}`);
+  }
+
+  if (!parsed.interactions || !Array.isArray(parsed.interactions)) {
+    throw new Error('Claude response missing interactions array');
+  }
+
+  return parsed.interactions
+    .filter((raw) => {
+      // Drop any entry missing required fields or with invalid severity
+      return (
+        typeof raw.item1 === 'string' &&
+        raw.item1.trim() !== '' &&
+        typeof raw.item2 === 'string' &&
+        raw.item2.trim() !== '' &&
+        VALID_SEVERITIES.has(raw.severity) &&
+        typeof raw.description === 'string' &&
+        typeof raw.recommendation === 'string' &&
+        typeof raw.citation === 'string'
+      );
+    })
+    .map((raw) => ({
+      item1: raw.item1.trim(),
+      item2: raw.item2.trim(),
+      severity: raw.severity as 'minor' | 'moderate' | 'major',
+      description: raw.description.trim(),
+      recommendation: raw.recommendation.trim(),
+      citation: raw.citation.trim(),
+    }));
+}
+
+async function runInteractionCheck(prompt: string): Promise<Interaction[]> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY is not set');
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  const message = await client.messages.create({
+    model: 'claude-haiku-4-5',
+    max_tokens: 2048,
+    messages: [
+      {
+        role: 'user',
+        content: prompt,
+      },
+    ],
+  });
+
+  const block = message.content[0];
+  if (!block || block.type !== 'text') {
+    throw new Error('Unexpected response format from Claude API');
+  }
+
+  return parseClaudeResponse(block.text);
+}
+
+/**
+ * Check all pairwise interactions for a user's full cabinet.
+ * Returns an empty array if the cabinet has fewer than 2 active items.
+ *
+ * Integration note for POST /cabinet and PUT /cabinet/:id:
+ *   After creating/updating an item, call checkNewItemInteractions(newItem, existingItems)
+ *   and include the result as `interactions` in the response body.
+ *   Example:
+ *     const interactions = await checkNewItemInteractions(savedItem, otherActiveItems);
+ *     res.json({ success: true, data: { ...savedItem.toObject(), interactions }, error: null });
+ */
+export async function checkCabinetInteractions(items: ICabinetItem[]): Promise<Interaction[]> {
+  if (items.length < 2) {
+    return [];
+  }
+  const prompt = buildPrompt(items);
+  return runInteractionCheck(prompt);
+}
+
+/**
+ * Check a single new item against existing cabinet items for interactions.
+ * Returns an empty array if there are no existing items to check against.
+ *
+ * Integration note for POST /cabinet and PUT /cabinet/:id:
+ *   Pass the newly saved item as `newItem` and all other active cabinet items
+ *   as `existingItems` (excluding the new item itself to avoid self-check).
+ */
+export async function checkNewItemInteractions(
+  newItem: ICabinetItem,
+  existingItems: ICabinetItem[]
+): Promise<Interaction[]> {
+  if (existingItems.length === 0) {
+    return [];
+  }
+  // Build a focused list: new item + existing items
+  const allItems = [newItem, ...existingItems];
+  const prompt = buildPrompt(allItems);
+  return runInteractionCheck(prompt);
+}


### PR DESCRIPTION
## What
Adds on-demand interaction checking between supplements and medications in a user's cabinet using Claude Haiku.

## Why
Closes #6

## Acceptance Criteria
- [x] GET /cabinet/interactions returns all detected interactions for user's active cabinet items
- [x] Each interaction has: item1, item2, severity (minor/moderate/major), description, recommendation, citation URL
- [x] Returns empty array if cabinet has fewer than 2 items or no interactions found
- [x] Returns 401 if not authenticated
- [x] Claude API prompt instructs model to only flag evidence-based interactions (no guessing)
- [x] Supports supplement-supplement, supplement-medication, medication-medication checks
- [x] Uses Claude Haiku (claude-haiku-4-5) for cost efficiency
- [x] npx tsc --noEmit passes

## Key files
- `src/services/interactionChecker.ts` — Claude Haiku integration; exports `checkCabinetInteractions` and `checkNewItemInteractions`
- `src/routes/interactions.ts` — GET /cabinet/interactions handler
- `src/index.ts` — mounts route behind `authenticate` middleware

## Integration note (for when feat/cabinet merges)
`checkNewItemInteractions` is designed to be called from POST /cabinet and PUT /cabinet/:id.
The integration comment in `interactionChecker.ts` shows the exact call pattern.

## Test Plan
1. Set `ANTHROPIC_API_KEY` and `MONGODB_URI` in `.env`
2. `npm run dev`
3. Sign in to get a JWT
4. `POST /cabinet` to add 2+ items (e.g. Magnesium + Zinc)
5. `GET /cabinet/interactions` with Bearer token — expect interactions array with severity + description + citation
6. `GET /cabinet/interactions` with no token — expect 401
7. Cabinet with 0 or 1 item — expect `{ interactions: [] }`