### PR TITLE
ops: Railway deployment config and CI (#8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: npm test
+
+      - name: Notify Telegram
+        if: always()
+        run: |
+          STATUS="${{ job.status }}"
+          ICON=$([ "$STATUS" = "success" ] && echo "✅" || echo "❌")
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d text="${ICON} CI ${STATUS}: ${{ github.repository }} — ${{ github.event.head_commit.message }}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Recallth Backend
+
+Express 5 + TypeScript + MongoDB API for the Recallth health advisor app.
+
+## Local Development
+
+```bash
+# Install dependencies
+npm install
+
+# Copy env template and fill in values
+cp .env.example .env
+
+# Start dev server (hot reload)
+npm run dev
+```
+
+## Scripts
+
+| Command | Description |
+|---|---|
+| `npm run dev` | Start dev server with ts-node-dev (hot reload) |
+| `npm run build` | Compile TypeScript to `dist/` |
+| `npm start` | Run compiled JS from `dist/index.js` |
+| `npm run typecheck` | Run tsc --noEmit (no output files) |
+
+## Deployment
+
+### Railway (Production)
+
+Railway auto-deploys from the `main` branch on every push. Configuration lives in `railway.toml`.
+
+**Manual first-time setup (Railway dashboard):**
+
+1. Go to [railway.app](https://railway.app) and create a new project
+2. Select "Deploy from GitHub repo" and connect `wkliwk/recallth-backend`
+3. Set the following environment variables in the Railway service settings:
+
+| Variable | Description | Example |
+|---|---|---|
+| `PORT` | Server port (Railway sets this automatically) | `3001` |
+| `NODE_ENV` | Runtime environment | `production` |
+| `MONGODB_URI` | MongoDB Atlas connection string | `mongodb+srv://user:pass@cluster.mongodb.net/recallth` |
+| `JWT_SECRET` | Secret for signing JWT tokens — min 32 chars, high entropy | — |
+| `ANTHROPIC_API_KEY` | Anthropic API key for AI features | `sk-ant-...` |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID for social login | `....apps.googleusercontent.com` |
+
+> Never commit secrets to the repo. Set them only in the Railway dashboard.
+
+4. Railway will detect `railway.toml` and run:
+   - Build: `npm run build` (via nixpacks)
+   - Start: `npm start`
+
+### Health Check
+
+The `/health` endpoint is configured as Railway's health check target. It must return HTTP 200 for Railway to consider the deployment healthy.
+
+```
+GET /health → 200 OK
+```
+
+### CORS
+
+In production, `CORS_ORIGIN` should be set to the exact Vercel frontend URL (e.g. `https://recallth.vercel.app`). In development it defaults to `http://localhost:3000`.
+
+## CI
+
+GitHub Actions runs on every push to `main` and on pull requests:
+- `npx tsc --noEmit` — fails the build on any TypeScript error
+- `npm test` — runs the test suite
+
+Add `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` to GitHub Actions secrets to enable Telegram notifications on CI pass/fail.

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "nixpacks"
+
+[deploy]
+startCommand = "npm start"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary

- Adds `railway.toml` — nixpacks builder, `/health` health check, on-failure restart policy (max 3 retries)
- Adds `.github/workflows/ci.yml` — runs `tsc --noEmit` + `npm test` on every push to main and on PRs; Telegram notification on pass/fail
- Adds `README.md` — deployment instructions, required env vars table, health check docs, CORS notes

## Required env vars (set in Railway dashboard — never in code)

| Variable | Description |
|---|---|
| `PORT` | Set automatically by Railway |
| `NODE_ENV` | `production` |
| `MONGODB_URI` | MongoDB Atlas connection string |
| `JWT_SECRET` | High-entropy secret, min 32 chars |
| `ANTHROPIC_API_KEY` | Anthropic API key |
| `GOOGLE_CLIENT_ID` | Google OAuth client ID |

## Manual Railway setup steps (one-time, Ricky to do via dashboard)

1. Go to railway.app → New Project → Deploy from GitHub → select `wkliwk/recallth-backend`
2. Add the env vars above in the Railway service Variables tab
3. Railway will detect `railway.toml` and auto-configure build + start commands
4. Verify the health check passes: `GET /health` should return 200

## GitHub Actions secrets needed

Add these to the repo settings → Secrets → Actions for Telegram CI notifications:
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_CHAT_ID`

## Verification

- `npx tsc --noEmit` — zero errors confirmed locally before this PR
- No secrets committed — all credentials documented for dashboard entry only

Closes #8