### PR TITLE
feat: switch AI from Anthropic to Google Gemini Flash (#35)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 PORT=3601
 MONGODB_URI=mongodb://localhost:27017/recallth
 JWT_SECRET=your-jwt-secret-here
-ANTHROPIC_API_KEY=your-anthropic-api-key-here
-GOODLE_CLIENT_ID=your-google-oauth-client-id-here
+GOOGLE_GEMINI_API_KEY=your-gemini-api-key-here
+GOOGLE_CLIENT_ID=your-google-oauth-client-id-here

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ npm run dev
    ```
    fly secrets set MONGODB_URI="your-atlas-connection-string"
    fly secrets set JWT_SECRET="your-jwt-secret-min-32-chars"
-   fly secrets set ANTHROPIC_API_KEY="sk-ant-..."
+   fly secrets set GOOGLE_GEMINI_API_KEY="your-gemini-api-key"
    fly secrets set GOOGLE_CLIENT_ID="your-client-id.apps.googleusercontent.com"
    ```
+   Get a free Gemini API key at: aistudio.google.com → Get API Key (free tier: 15 RPM, 1M tokens/day)
 5. Deploy: `fly deploy`
 
 ### MongoDB

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.87.0",
+        "@google/generative-ai": "^0.24.1",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.6",
         "dotenv": "^17.4.1",
@@ -28,35 +28,6 @@
         "prettier": "^3.8.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^6.0.2"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.87.0.tgz",
-      "integrity": "sha512-ZvBWT5VkPTW6b8LIpugpuAkpcYPSLOXdWTcgQrpUqf4IeJ5ZrH5rT8sTsUDvxPCHAlRG3nF4VIWfjw6uLhJ18g==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -177,6 +148,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1819,19 +1799,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2892,12 +2859,6 @@
       "bin": {
         "tree-kill": "cli.js"
       }
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/wkliwk/recallth-backend#readme",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.87.0",
+    "@google/generative-ai": "^0.24.1",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",

--- a/src/config/models.ts
+++ b/src/config/models.ts
@@ -1,5 +1,5 @@
 export const MODELS = {
-  CHAT: 'claude-sonnet-4-6',                   // complex health advice — requires reasoning + nuance
-  EXTRACTION: 'claude-haiku-4-5-20251001',      // data extraction — structured output, no reasoning needed
-  INTERACTION: 'claude-haiku-4-5-20251001',     // supplement interaction checking — structured checklist task
+  CHAT: 'gemini-2.0-flash',
+  EXTRACTION: 'gemini-2.0-flash',
+  INTERACTION: 'gemini-2.0-flash',
 } as const;

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,4 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
+import { GoogleGenerativeAI } from '@google/generative-ai';
 import { Types } from 'mongoose';
 import { HealthProfile, IHealthProfile } from '../models/HealthProfile';
 import { CabinetItem, ICabinetItem } from '../models/CabinetItem';
@@ -7,9 +7,7 @@ import { Conversation } from '../models/Conversation';
 import { detectLanguage, DetectedLanguage } from '../utils/language';
 import { MODELS } from '../config/models';
 
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-});
+const genAI = new GoogleGenerativeAI(process.env.GOOGLE_GEMINI_API_KEY!);
 
 // --- Rate limiting ---
 interface RateLimitEntry {
@@ -187,19 +185,16 @@ Extract these fields if mentioned (use null for anything not mentioned):
   "cabinetItems": [{ "name": null, "dosage": null, "frequency": null, "timing": null, "brand": null }]
 }
 
-Only include fields explicitly stated. Return null if nothing to extract.`;
+Only include fields explicitly stated. Return null if nothing to extract. Respond only with JSON.`;
 
-  const response = await anthropic.messages.create({
-    model: MODELS.EXTRACTION,
-    max_tokens: 1024,
-    messages: [{ role: 'user', content: extractionPrompt }],
-  });
+  const model = genAI.getGenerativeModel({ model: MODELS.EXTRACTION });
+  const result = await model.generateContent(extractionPrompt);
+  const text = result.response.text().trim();
 
+  const usage = result.response.usageMetadata;
   console.log(
-    `[AI] model=${MODELS.EXTRACTION} input_tokens=${response.usage.input_tokens} output_tokens=${response.usage.output_tokens} task=extraction`
+    `[AI] model=${MODELS.EXTRACTION} input_tokens=${usage?.promptTokenCount} output_tokens=${usage?.candidatesTokenCount} task=extraction`
   );
-
-  const text = response.content[0].type === 'text' ? response.content[0].text.trim() : '';
 
   if (!text || text === 'null') return null;
 
@@ -358,28 +353,30 @@ export async function processChat(
   const userMsg = { role: 'user' as const, content: userMessage, timestamp: new Date() };
   conversation.messages.push(userMsg);
 
-  // Build message history for Claude (last 20 messages for context window)
-  const historyForClaude = conversation.messages.slice(-20).map((m) => ({
-    role: m.role as 'user' | 'assistant',
-    content: m.content,
+  // Build message history for Gemini (last 20 messages for context window, excluding the latest user message)
+  const allMessages = conversation.messages.slice(-20);
+  // History is all messages except the last user message (which we send via sendMessage)
+  const historyMessages = allMessages.slice(0, -1);
+  const history = historyMessages.map((m) => ({
+    role: m.role === 'assistant' ? ('model' as const) : ('user' as const),
+    parts: [{ text: m.content }],
   }));
 
-  // Call Claude for chat response
+  // Call Gemini for chat response
   const systemPrompt = buildSystemPrompt(profile, cabinetItems, language);
-
-  const chatResponse = await anthropic.messages.create({
+  const model = genAI.getGenerativeModel({
     model: MODELS.CHAT,
-    max_tokens: 2048,
-    system: systemPrompt,
-    messages: historyForClaude,
+    systemInstruction: systemPrompt,
   });
 
-  console.log(
-    `[AI] model=${MODELS.CHAT} input_tokens=${chatResponse.usage.input_tokens} output_tokens=${chatResponse.usage.output_tokens} task=chat`
-  );
+  const chat = model.startChat({ history });
+  const chatResult = await chat.sendMessage(userMessage);
+  const assistantContent = chatResult.response.text();
 
-  const assistantContent =
-    chatResponse.content[0].type === 'text' ? chatResponse.content[0].text : '';
+  const usage = chatResult.response.usageMetadata;
+  console.log(
+    `[AI] model=${MODELS.CHAT} input_tokens=${usage?.promptTokenCount} output_tokens=${usage?.candidatesTokenCount} task=chat`
+  );
 
   const assistantMsg = {
     role: 'assistant' as const,

--- a/src/services/interactionChecker.ts
+++ b/src/services/interactionChecker.ts
@@ -1,4 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
+import { GoogleGenerativeAI } from '@google/generative-ai';
 import { ICabinetItem } from '../models/CabinetItem';
 import { MODELS } from '../config/models';
 
@@ -11,7 +11,7 @@ export interface Interaction {
   citation: string;
 }
 
-interface ClaudeInteractionResponse {
+interface GeminiInteractionResponse {
   interactions: Array<{
     item1: string;
     item2: string;
@@ -91,16 +91,19 @@ Rules:
 - Return ONLY valid JSON, no other text`;
 }
 
-function parseClaudeResponse(content: string): Interaction[] {
-  let parsed: ClaudeInteractionResponse;
+function parseGeminiResponse(content: string): Interaction[] {
+  // Strip markdown code fences if present
+  const cleaned = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+
+  let parsed: GeminiInteractionResponse;
   try {
-    parsed = JSON.parse(content) as ClaudeInteractionResponse;
+    parsed = JSON.parse(cleaned) as GeminiInteractionResponse;
   } catch {
-    throw new Error(`Claude returned non-JSON response: ${content.slice(0, 200)}`);
+    throw new Error(`Gemini returned non-JSON response: ${content.slice(0, 200)}`);
   }
 
   if (!parsed.interactions || !Array.isArray(parsed.interactions)) {
-    throw new Error('Claude response missing interactions array');
+    throw new Error('Gemini response missing interactions array');
   }
 
   return parsed.interactions
@@ -128,9 +131,9 @@ function parseClaudeResponse(content: string): Interaction[] {
 }
 
 async function runInteractionCheck(items: ICabinetItem[], prompt: string): Promise<Interaction[]> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey = process.env.GOOGLE_GEMINI_API_KEY;
   if (!apiKey) {
-    throw new Error('ANTHROPIC_API_KEY is not set');
+    throw new Error('GOOGLE_GEMINI_API_KEY is not set');
   }
 
   // Check cache before making API call
@@ -142,29 +145,18 @@ async function runInteractionCheck(items: ICabinetItem[], prompt: string): Promi
     return cached.result;
   }
 
-  const client = new Anthropic({ apiKey });
+  const client = new GoogleGenerativeAI(apiKey);
+  const model = client.getGenerativeModel({ model: MODELS.INTERACTION });
 
-  const message = await client.messages.create({
-    model: MODELS.INTERACTION,
-    max_tokens: 2048,
-    messages: [
-      {
-        role: 'user',
-        content: prompt,
-      },
-    ],
-  });
+  const response = await model.generateContent(prompt);
+  const text = response.response.text();
 
+  const usage = response.response.usageMetadata;
   console.log(
-    `[AI] model=${MODELS.INTERACTION} input_tokens=${message.usage.input_tokens} output_tokens=${message.usage.output_tokens} task=interaction cache_hit=false`
+    `[AI] model=${MODELS.INTERACTION} input_tokens=${usage?.promptTokenCount} output_tokens=${usage?.candidatesTokenCount} task=interaction cache_hit=false`
   );
 
-  const block = message.content[0];
-  if (!block || block.type !== 'text') {
-    throw new Error('Unexpected response format from Claude API');
-  }
-
-  const result = parseClaudeResponse(block.text);
+  const result = parseGeminiResponse(text);
 
   // Store in cache with TTL
   interactionCache.set(cacheKey, { result, expiresAt: now + CACHE_TTL_MS });


### PR DESCRIPTION
## What
Replace the Anthropic Claude SDK with Google Generative AI (Gemini Flash) across all AI service calls.

**Files changed:**
- `src/config/models.ts` — all three model slots now point to `gemini-2.0-flash`
- `src/services/chatService.ts` — rewritten to use `GoogleGenerativeAI`, `startChat` with history, `systemInstruction` replacing Anthropic's `system` param
- `src/services/interactionChecker.ts` — rewritten to use `model.generateContent`, updated error messages and env var check
- `.env.example` — `ANTHROPIC_API_KEY` → `GOOGLE_GEMINI_API_KEY` (also fixed the pre-existing typo `GOODLE_CLIENT_ID` → `GOOGLE_CLIENT_ID`)
- `README.md` — updated fly secrets example, added note pointing to aistudio.google.com for free key
- `package.json` / `package-lock.json` — removed `@anthropic-ai/sdk`, added `@google/generative-ai`

## Why
Closes #35

Anthropic has no free tier. Gemini Flash free tier (15 RPM, 1M tokens/day) is sufficient for MVP testing.

## Acceptance Criteria
- [x] `@anthropic-ai/sdk` removed from dependencies
- [x] `@google/generative-ai` installed
- [x] All three model slots use `gemini-2.0-flash`
- [x] `chatService.ts` uses Gemini multi-turn chat with `systemInstruction` and `'model'` role for history
- [x] `interactionChecker.ts` uses `model.generateContent` with same prompt logic
- [x] Env var is `GOOGLE_GEMINI_API_KEY` (not `GOOGLE_API_KEY`)
- [x] `.env.example` and `README.md` updated
- [x] `npx tsc --noEmit` — zero errors
- [x] Zero remaining Anthropic references in `src/`

## Test Plan
1. Set `GOOGLE_GEMINI_API_KEY` from aistudio.google.com
2. `npm run dev`
3. POST `/chat` with a health-related message — verify Gemini response returns
4. Add two cabinet items, GET `/cabinet/interactions` — verify interaction check runs via Gemini
5. Check console logs show `model=gemini-2.0-flash` token counts