### PR TITLE
feat: family profiles backend — FamilyMember model + memberId scoping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import chatRouter from './routes/chat';
 import interactionsRouter from './routes/interactions';
 import historyRouter from './routes/history';
 import extractionReviewRouter from './routes/extractionReview';
+import familyMembersRouter from './routes/familyMembers';
 import { authenticate } from './middleware/auth';
 
 dotenv.config();
@@ -32,6 +33,7 @@ app.use('/cabinet', authenticate, cabinetRouter);
 app.use('/cabinet/interactions', authenticate, interactionsRouter);
 app.use('/chat', authenticate, chatRouter);
 app.use('/history', authenticate, historyRouter);
+app.use('/family-members', familyMembersRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/models/FamilyMember.ts
+++ b/src/models/FamilyMember.ts
@@ -1,0 +1,20 @@
+import mongoose, { Document, Schema, Types } from 'mongoose';
+
+export interface IFamilyMember extends Document {
+  ownerId: Types.ObjectId;   // the primary user who owns this family member entry
+  name: string;
+  relationship?: string;     // e.g. 'Mum', 'Dad', 'Child', 'Partner'
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const FamilyMemberSchema = new Schema<IFamilyMember>(
+  {
+    ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    name: { type: String, required: true, trim: true },
+    relationship: { type: String, trim: true },
+  },
+  { timestamps: true }
+);
+
+export const FamilyMember = mongoose.model<IFamilyMember>('FamilyMember', FamilyMemberSchema);

--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -1,11 +1,23 @@
 import { Router, Response, Request } from 'express';
-import mongoose from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 import crypto from 'crypto';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { AuthRequest } from '../middleware/auth';
 import { CabinetItem, CabinetItemType } from '../models/CabinetItem';
 import { SharedStack } from '../models/SharedStack';
+import { FamilyMember } from '../models/FamilyMember';
 import { MODELS } from '../config/models';
+
+async function resolveScopedUserId(
+  ownerId: Types.ObjectId,
+  memberId?: string
+): Promise<Types.ObjectId | null> {
+  if (!memberId) return ownerId;
+  if (!Types.ObjectId.isValid(memberId)) return null;
+  const member = await FamilyMember.findOne({ _id: memberId, ownerId }).lean();
+  if (!member) return null;
+  return member._id as Types.ObjectId;
+}
 
 const getGenAI = () => {
   const apiKey = process.env.GOOGLE_GEMINI_API_KEY;
@@ -17,6 +29,13 @@ const router = Router();
 
 // POST /cabinet — add item
 router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const ownerId = new Types.ObjectId(req.userId);
+  const scopedUserId = await resolveScopedUserId(ownerId, req.query.memberId as string | undefined);
+  if (!scopedUserId) {
+    res.status(404).json({ success: false, data: null, error: 'Family member not found' });
+    return;
+  }
+
   const { name, type, dosage, frequency, timing, brand, notes, active, startDate, endDate, source, price, currency } = req.body;
 
   if (!name || typeof name !== 'string' || name.trim() === '') {
@@ -31,7 +50,7 @@ router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
   }
 
   const item = await CabinetItem.create({
-    userId: req.userId,
+    userId: scopedUserId,
     name: name.trim(),
     type,
     dosage,
@@ -56,7 +75,13 @@ router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
 
 // GET /cabinet — list user's items with optional filters
 router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
-  const query: Record<string, unknown> = { userId: req.userId };
+  const ownerId = new Types.ObjectId(req.userId);
+  const scopedUserId = await resolveScopedUserId(ownerId, req.query.memberId as string | undefined);
+  if (!scopedUserId) {
+    res.status(404).json({ success: false, data: null, error: 'Family member not found' });
+    return;
+  }
+  const query: Record<string, unknown> = { userId: scopedUserId };
 
   const validTypes: CabinetItemType[] = ['supplement', 'medication', 'vitamin'];
   if (req.query.type) {

--- a/src/routes/familyMembers.ts
+++ b/src/routes/familyMembers.ts
@@ -1,0 +1,61 @@
+import { Router, Response } from 'express';
+import { Types } from 'mongoose';
+import { authenticate, AuthRequest } from '../middleware/auth';
+import { FamilyMember } from '../models/FamilyMember';
+import { HealthProfile } from '../models/HealthProfile';
+import { CabinetItem } from '../models/CabinetItem';
+
+const router = Router();
+
+// GET /family-members — list all family members for the authed user
+router.get('/', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const ownerId = new Types.ObjectId(req.userId);
+  const members = await FamilyMember.find({ ownerId }).sort({ createdAt: 1 }).lean();
+  res.json({ success: true, data: members, error: null });
+});
+
+// POST /family-members — create a new family member
+router.post('/', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const ownerId = new Types.ObjectId(req.userId);
+  const { name, relationship } = req.body as { name?: string; relationship?: string };
+
+  if (!name || typeof name !== 'string' || name.trim() === '') {
+    res.status(400).json({ success: false, data: null, error: 'name is required' });
+    return;
+  }
+
+  const member = await FamilyMember.create({
+    ownerId,
+    name: name.trim(),
+    relationship: relationship?.trim() ?? undefined,
+  });
+
+  res.status(201).json({ success: true, data: member, error: null });
+});
+
+// DELETE /family-members/:id — delete a family member and their data
+router.delete('/:id', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const ownerId = new Types.ObjectId(req.userId);
+  const memberId = String(req.params.id);
+
+  if (!Types.ObjectId.isValid(memberId)) {
+    res.status(400).json({ success: false, data: null, error: 'Invalid member id' });
+    return;
+  }
+
+  const member = await FamilyMember.findOneAndDelete({ _id: memberId, ownerId });
+  if (!member) {
+    res.status(404).json({ success: false, data: null, error: 'Family member not found' });
+    return;
+  }
+
+  // Cascade-delete their profile and cabinet data (keyed by member._id as their userId)
+  await Promise.all([
+    HealthProfile.deleteOne({ userId: member._id }),
+    CabinetItem.deleteMany({ userId: member._id }),
+  ]);
+
+  res.json({ success: true, data: null, error: null });
+});
+
+export default router;

--- a/src/routes/profile.ts
+++ b/src/routes/profile.ts
@@ -4,6 +4,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { authenticate, AuthRequest } from '../middleware/auth';
 import { HealthProfile, IChangeEntry } from '../models/HealthProfile';
 import { CabinetItem } from '../models/CabinetItem';
+import { FamilyMember } from '../models/FamilyMember';
 import { MODELS } from '../config/models';
 
 const getGenAI = () => {
@@ -14,9 +15,23 @@ const getGenAI = () => {
 
 const router = Router();
 
-// All routes in this file are protected — authenticate is applied at mount time
-// in index.ts, so we re-declare it here only for the inline router usage.
-// The router itself is exported and mounted with authenticate already applied.
+// ─── Family member scope helper ───────────────────────────────────────────
+
+/**
+ * If ?memberId= is present, validate it belongs to the authed user and return
+ * the member's ObjectId as the effective userId. Otherwise return the authed userId.
+ * Returns null if memberId is invalid or not owned by the authed user.
+ */
+async function resolveScopedUserId(
+  ownerId: Types.ObjectId,
+  memberId?: string
+): Promise<Types.ObjectId | null> {
+  if (!memberId) return ownerId;
+  if (!Types.ObjectId.isValid(memberId)) return null;
+  const member = await FamilyMember.findOne({ _id: memberId, ownerId }).lean();
+  if (!member) return null;
+  return member._id as Types.ObjectId;
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -69,7 +84,12 @@ function buildChangeEntries(
 // ─── GET /profile ──────────────────────────────────────────────────────────
 
 router.get('/', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = new Types.ObjectId(req.userId);
+  const ownerId = new Types.ObjectId(req.userId);
+  const userId = await resolveScopedUserId(ownerId, req.query.memberId as string | undefined);
+  if (!userId) {
+    res.status(404).json({ success: false, data: null, error: 'Family member not found' });
+    return;
+  }
 
   const profile = await HealthProfile.findOne({ userId });
 
@@ -98,7 +118,12 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response): Promise<v
 // ─── PUT /profile ──────────────────────────────────────────────────────────
 
 router.put('/', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = new Types.ObjectId(req.userId);
+  const ownerId = new Types.ObjectId(req.userId);
+  const userId = await resolveScopedUserId(ownerId, req.query.memberId as string | undefined);
+  if (!userId) {
+    res.status(404).json({ success: false, data: null, error: 'Family member not found' });
+    return;
+  }
 
   // Only accept recognised top-level category keys
   const ALLOWED_CATEGORIES = ['body', 'diet', 'exercise', 'sleep', 'lifestyle', 'goals', 'bloodwork'] as const;
@@ -190,7 +215,8 @@ router.put('/', authenticate, async (req: AuthRequest, res: Response): Promise<v
 // ─── GET /profile/weight-trend ─────────────────────────────────────────────
 
 router.get('/weight-trend', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = new Types.ObjectId(req.userId);
+  const ownerId = new Types.ObjectId(req.userId);
+  const userId = await resolveScopedUserId(ownerId, req.query.memberId as string | undefined) ?? ownerId;
 
   const profile = await HealthProfile.findOne({ userId }, { changeHistory: 1, 'body.weight': 1 }).lean();
 


### PR DESCRIPTION
## Summary
- New `FamilyMember` model: `{ ownerId, name, relationship }` — owned by the primary user
- `GET/POST/DELETE /family-members` routes for managing family members
- Deleting a member cascade-deletes their HealthProfile and CabinetItem documents
- `GET/PUT /profile` and `GET/POST /cabinet` now accept `?memberId=` query param
- When memberId is provided, validates ownership then uses member._id as the scoped userId for all queries

## Design
Family members don't have their own User account — they're sub-profiles under the primary user. Their health/cabinet data is keyed by `familyMember._id` as the userId, which slots into the existing data model without schema changes.

## Test plan
- [ ] POST /family-members → creates member
- [ ] GET /family-members → lists members
- [ ] GET /profile?memberId=xxx → returns empty profile for new member
- [ ] PUT /profile?memberId=xxx → saves profile scoped to member
- [ ] GET /cabinet?memberId=xxx → returns member's cabinet items
- [ ] DELETE /family-members/:id → deletes member + cascades

🤖 Generated with [Claude Code](https://claude.com/claude-code)