### PR TITLE
feat: PDF health report export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,15 @@
       "license": "ISC",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "@types/pdfkit": "^0.17.5",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.6",
         "dotenv": "^17.4.1",
         "express": "^5.2.1",
         "google-auth-library": "^10.6.2",
         "jsonwebtoken": "^9.0.3",
-        "mongoose": "^9.4.1"
+        "mongoose": "^9.4.1",
+        "pdfkit": "^0.18.0"
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
@@ -248,6 +250,39 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -392,10 +427,18 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/pdfkit": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/pdfkit/-/pdfkit-0.17.5.tgz",
+      "integrity": "sha512-T3ZHnvF91HsEco5ClhBCOuBwobZfPcI2jaiSHybkkKYq4KhVIIurod94JVKvDIG0JXT6o3KiERC0X0//m8dyrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -674,6 +717,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/bson": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
@@ -770,6 +822,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/concat-map": {
@@ -899,6 +960,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -1233,7 +1300,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1357,6 +1423,23 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -1783,6 +1866,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -1887,6 +1976,25 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/locate-path": {
@@ -2334,6 +2442,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2390,6 +2504,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pdfkit": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.18.0.tgz",
+      "integrity": "sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "fontkit": "^2.0.4",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
@@ -2402,6 +2530,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -2523,6 +2656,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "2.7.1",
@@ -2816,6 +2955,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2952,6 +3097,12 @@
         "strip-json-comments": "^2.0.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2997,8 +3148,27 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,13 +24,15 @@
   "homepage": "https://github.com/wkliwk/recallth-backend#readme",
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@types/pdfkit": "^0.17.5",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.6",
     "dotenv": "^17.4.1",
     "express": "^5.2.1",
     "google-auth-library": "^10.6.2",
     "jsonwebtoken": "^9.0.3",
-    "mongoose": "^9.4.1"
+    "mongoose": "^9.4.1",
+    "pdfkit": "^0.18.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import extractionReviewRouter from './routes/extractionReview';
 import familyMembersRouter from './routes/familyMembers';
 import wellnessRouter from './routes/wellness';
 import sideEffectsRouter from './routes/sideEffects';
+import exportRouter from './routes/export';
 import { authenticate } from './middleware/auth';
 
 dotenv.config();
@@ -38,6 +39,7 @@ app.use('/history', authenticate, historyRouter);
 app.use('/family-members', familyMembersRouter);
 app.use('/wellness', authenticate, wellnessRouter);
 app.use('/side-effects', authenticate, sideEffectsRouter);
+app.use('/export', authenticate, exportRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -1,0 +1,280 @@
+import { Router, Response } from 'express';
+import PDFDocument from 'pdfkit';
+import { Types } from 'mongoose';
+import { AuthRequest } from '../middleware/auth';
+import { HealthProfile } from '../models/HealthProfile';
+import { CabinetItem } from '../models/CabinetItem';
+import { SideEffect } from '../models/SideEffect';
+import { checkCabinetInteractions, Interaction } from '../services/interactionChecker';
+
+const router = Router();
+
+// Helpers
+function or(val: unknown, fallback = 'Not provided'): string {
+  if (val === undefined || val === null || val === '') return fallback;
+  if (Array.isArray(val)) return val.length === 0 ? fallback : val.join(', ');
+  return String(val);
+}
+
+function sectionTitle(doc: PDFKit.PDFDocument, title: string) {
+  doc
+    .moveDown(0.5)
+    .font('Helvetica-Bold')
+    .fontSize(13)
+    .fillColor('#1a1a1a')
+    .text(title);
+  doc.moveTo(doc.page.margins.left, doc.y + 2)
+    .lineTo(doc.page.width - doc.page.margins.right, doc.y + 2)
+    .strokeColor('#cccccc')
+    .lineWidth(0.5)
+    .stroke();
+  doc.moveDown(0.4);
+  doc.font('Helvetica').fontSize(10).fillColor('#333333');
+}
+
+function kv(doc: PDFKit.PDFDocument, label: string, value: string) {
+  doc.font('Helvetica-Bold').fontSize(10).text(`${label}: `, { continued: true });
+  doc.font('Helvetica').fontSize(10).text(value);
+}
+
+function tableRow(
+  doc: PDFKit.PDFDocument,
+  cols: string[],
+  widths: number[],
+  x: number,
+  isHeader = false
+) {
+  const y = doc.y;
+  let cx = x;
+  doc.font(isHeader ? 'Helvetica-Bold' : 'Helvetica').fontSize(9);
+  for (let i = 0; i < cols.length; i++) {
+    doc.text(cols[i] ?? '', cx + 3, y, { width: widths[i] - 6, lineBreak: false });
+    cx += widths[i];
+  }
+  // Advance by row height (approx 14pt)
+  doc.y = y + 14;
+}
+
+// GET /export/pdf
+router.get('/pdf', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = new Types.ObjectId(req.userId);
+
+  const [profile, cabinetItems, sideEffects] = await Promise.all([
+    HealthProfile.findOne({ userId }).lean(),
+    CabinetItem.find({ userId, active: true }).sort({ name: 1 }).lean(),
+    SideEffect.find({ userId }).sort({ date: -1 }).limit(30).lean(),
+  ]);
+
+  // Resolve supplement names for side effects
+  const allItemIds = [...new Set(sideEffects.map((s) => s.cabinetItemId.toString()))];
+  const allItems = await CabinetItem.find({ _id: { $in: allItemIds } }).lean();
+  const itemNameMap = new Map(allItems.map((i) => [(i._id as Types.ObjectId).toString(), i.name]));
+
+  // Fetch interactions (non-fatal)
+  let interactions: Interaction[] = [];
+  try {
+    interactions = await checkCabinetInteractions(cabinetItems as Parameters<typeof checkCabinetInteractions>[0]);
+  } catch {
+    // swallow — interactions are best-effort
+  }
+
+  // Build wellness score (deterministic part only — no AI on export)
+  const profileScore = (() => {
+    if (!profile) return 0;
+    const fields = [
+      profile.body?.height, profile.body?.weight, profile.body?.age, profile.body?.sex,
+      profile.diet?.dietType, profile.exercise?.frequency, profile.sleep?.quality,
+      profile.lifestyle?.stressLevel, profile.goals?.primary,
+    ];
+    const filled = fields.filter((f) => f !== undefined && f !== null && String(f).trim() !== '' && !(Array.isArray(f) && f.length === 0)).length;
+    return Math.round((filled / fields.length) * 40);
+  })();
+
+  // ── Build PDF ─────────────────────────────────────────────────────────────
+  const doc = new PDFDocument({ margin: 50, size: 'A4', bufferPages: true });
+
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', 'attachment; filename="recallth-health-report.pdf"');
+  doc.pipe(res);
+
+  const pageWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+  const leftX = doc.page.margins.left;
+
+  // ── 1. Header ────────────────────────────────────────────────────────────
+  doc.font('Helvetica-Bold').fontSize(20).fillColor('#16a34a').text('Recallth Health Report', leftX);
+  doc.font('Helvetica').fontSize(10).fillColor('#555555')
+    .text(`Generated: ${new Date().toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })}`)
+    .moveDown(0.2);
+  doc.font('Helvetica').fontSize(9).fillColor('#888888')
+    .text('This report is for personal use only. It is not a substitute for professional medical advice.');
+  doc.moveDown(0.8);
+
+  // ── 2. Health Profile ────────────────────────────────────────────────────
+  sectionTitle(doc, '1. Health Profile');
+
+  if (!profile) {
+    doc.text('No health profile found.');
+  } else {
+    const b = profile.body ?? {};
+    const d = profile.diet ?? {};
+    const e = profile.exercise ?? {};
+    const s = profile.sleep ?? {};
+    const l = profile.lifestyle ?? {};
+    const g = profile.goals ?? {};
+    const bw = profile.bloodwork ?? {};
+
+    doc.font('Helvetica-Bold').fontSize(10).text('Body');
+    doc.font('Helvetica').fontSize(10);
+    kv(doc, 'Height', or(b.height ? `${b.height} cm` : ''));
+    kv(doc, 'Weight', or(b.weight ? `${b.weight} kg` : ''));
+    kv(doc, 'Age', or(b.age));
+    kv(doc, 'Sex', or(b.sex));
+    kv(doc, 'Body goals', or(b.bodyCompositionGoals));
+    doc.moveDown(0.3);
+
+    doc.font('Helvetica-Bold').fontSize(10).text('Diet');
+    kv(doc, 'Diet type', or(d.dietType));
+    kv(doc, 'Preferences', or(d.preferences));
+    kv(doc, 'Allergies', or(d.allergies));
+    kv(doc, 'Intolerances', or(d.intolerances));
+    doc.moveDown(0.3);
+
+    doc.font('Helvetica-Bold').fontSize(10).text('Exercise');
+    kv(doc, 'Type', or(e.type));
+    kv(doc, 'Frequency', or(e.frequency));
+    kv(doc, 'Intensity', or(e.intensity));
+    kv(doc, 'Goals', or(e.goals));
+    doc.moveDown(0.3);
+
+    doc.font('Helvetica-Bold').fontSize(10).text('Sleep');
+    kv(doc, 'Schedule', or(s.schedule));
+    kv(doc, 'Quality', or(s.quality));
+    kv(doc, 'Issues', or(s.issues));
+    doc.moveDown(0.3);
+
+    doc.font('Helvetica-Bold').fontSize(10).text('Lifestyle');
+    kv(doc, 'Stress level', or(l.stressLevel));
+    kv(doc, 'Work type', or(l.workType));
+    kv(doc, 'Alcohol', or(l.alcohol));
+    kv(doc, 'Smoking', or(l.smoking));
+    doc.moveDown(0.3);
+
+    doc.font('Helvetica-Bold').fontSize(10).text('Goals');
+    kv(doc, 'Primary goals', or(g.primary));
+    doc.moveDown(0.3);
+
+    const bwFields = [
+      ['HbA1c', bw.hba1c ? `${bw.hba1c}%` : null],
+      ['Total cholesterol', bw.totalCholesterol ? `${bw.totalCholesterol} mmol/L` : null],
+      ['LDL', bw.ldl ? `${bw.ldl} mmol/L` : null],
+      ['HDL', bw.hdl ? `${bw.hdl} mmol/L` : null],
+      ['Triglycerides', bw.triglycerides ? `${bw.triglycerides} mmol/L` : null],
+      ['Fasting glucose', bw.fastingGlucose ? `${bw.fastingGlucose} mmol/L` : null],
+      ['Ferritin', bw.ferritin ? `${bw.ferritin} ng/mL` : null],
+      ['Vitamin D', bw.vitaminD ? `${bw.vitaminD} nmol/L` : null],
+      ['Vitamin B12', bw.vitaminB12 ? `${bw.vitaminB12} pmol/L` : null],
+      ['TSH', bw.tsh ? `${bw.tsh} mIU/L` : null],
+    ].filter(([, v]) => v !== null) as [string, string][];
+
+    if (bwFields.length > 0) {
+      doc.font('Helvetica-Bold').fontSize(10).text('Bloodwork');
+      for (const [label, val] of bwFields) kv(doc, label, val);
+      if (bw.testedAt) kv(doc, 'Tested at', bw.testedAt);
+    }
+  }
+
+  // ── 3. Supplement Cabinet ────────────────────────────────────────────────
+  sectionTitle(doc, '2. Supplement Cabinet (Active)');
+
+  if (cabinetItems.length === 0) {
+    doc.text('No supplements added.');
+  } else {
+    const colWidths = [140, 75, 75, 80, 80, 80];
+    const headers = ['Name', 'Type', 'Dosage', 'Frequency', 'Timing', 'Brand'];
+    tableRow(doc, headers, colWidths, leftX, true);
+    doc.moveTo(leftX, doc.y).lineTo(leftX + pageWidth, doc.y).strokeColor('#cccccc').lineWidth(0.5).stroke();
+
+    for (const item of cabinetItems) {
+      if (doc.y > doc.page.height - 100) {
+        doc.addPage();
+        tableRow(doc, headers, colWidths, leftX, true);
+        doc.moveTo(leftX, doc.y).lineTo(leftX + pageWidth, doc.y).strokeColor('#cccccc').lineWidth(0.5).stroke();
+      }
+      tableRow(doc, [
+        item.name,
+        item.type,
+        or(item.dosage, '—'),
+        or(item.frequency, '—'),
+        or(item.timing, '—'),
+        or(item.brand, '—'),
+      ], colWidths, leftX);
+    }
+  }
+
+  // ── 4. Side Effects Log ──────────────────────────────────────────────────
+  sectionTitle(doc, '3. Side Effects Log (Last 30)');
+
+  if (sideEffects.length === 0) {
+    doc.text('No reactions logged.');
+  } else {
+    const colWidths = [140, 160, 60, 100];
+    const headers = ['Supplement', 'Symptom', 'Severity', 'Date'];
+    tableRow(doc, headers, colWidths, leftX, true);
+    doc.moveTo(leftX, doc.y).lineTo(leftX + pageWidth, doc.y).strokeColor('#cccccc').lineWidth(0.5).stroke();
+
+    for (const se of sideEffects) {
+      if (doc.y > doc.page.height - 100) {
+        doc.addPage();
+        tableRow(doc, headers, colWidths, leftX, true);
+        doc.moveTo(leftX, doc.y).lineTo(leftX + pageWidth, doc.y).strokeColor('#cccccc').lineWidth(0.5).stroke();
+      }
+      const suppName = itemNameMap.get(se.cabinetItemId.toString()) ?? 'Unknown';
+      tableRow(doc, [
+        suppName,
+        se.symptom,
+        `${se.rating}/5`,
+        new Date(se.date).toLocaleDateString('en-GB'),
+      ], colWidths, leftX);
+    }
+  }
+
+  // ── 5. Wellness Score ────────────────────────────────────────────────────
+  sectionTitle(doc, '4. Wellness Score');
+  doc.text(`Profile Completeness Score (deterministic): ${profileScore}/40`);
+  doc.moveDown(0.2);
+  doc.font('Helvetica').fontSize(9).fillColor('#888888')
+    .text('Note: Goal Alignment score requires the live app. See dashboard for full score.');
+  doc.fillColor('#333333').fontSize(10);
+
+  // ── 6. Detected Interactions ─────────────────────────────────────────────
+  sectionTitle(doc, '5. Detected Interactions');
+
+  if (interactions.length === 0) {
+    doc.text('No interactions detected.');
+  } else {
+    for (const interaction of interactions) {
+      doc.font('Helvetica-Bold').fontSize(10)
+        .text(`${interaction.item1} + ${interaction.item2}`, { continued: true });
+      doc.font('Helvetica').text(` (${interaction.severity})`);
+      doc.font('Helvetica').fontSize(9).fillColor('#555555').text(interaction.description);
+      doc.fillColor('#333333').fontSize(10).moveDown(0.3);
+    }
+  }
+
+  // ── Footer on all pages ───────────────────────────────────────────────────
+  const pageCount = (doc.bufferedPageRange().count);
+  for (let i = 0; i < pageCount; i++) {
+    doc.switchToPage(i);
+    doc.font('Helvetica').fontSize(8).fillColor('#aaaaaa')
+      .text(
+        'This report was generated by Recallth. It is not medical advice. Always consult a qualified healthcare professional.',
+        doc.page.margins.left,
+        doc.page.height - 40,
+        { width: pageWidth, align: 'center' }
+      );
+  }
+
+  doc.end();
+});
+
+export default router;


### PR DESCRIPTION
## What
- Added `pdfkit` + `@types/pdfkit` dependencies
- Created `src/routes/export.ts` with `GET /export/pdf`
- Registered at `app.use('/export', authenticate, exportRouter)` in `index.ts`

## Report Sections
1. **Header** — Recallth branding, generation date, disclaimer
2. **Health Profile** — body, diet, exercise, sleep, lifestyle, goals, bloodwork (non-null fields only; empty categories show gracefully)
3. **Supplement Cabinet** — table of active items (name, type, dosage, frequency, timing, brand); paginates with re-printed headers if > ~40 items
4. **Side Effects Log** — last 30 reactions sorted by date descending; resolves supplement names via CabinetItem lookup
5. **Wellness Score** — deterministic profile completeness score (40pt); notes AI portion available in live app
6. **Detected Interactions** — re-runs interaction checker on export; swallowed non-fatally if it fails
7. **Footer** — disclaimer on every page via `doc.bufferedPageRange()`

## Acceptance Criteria
- [x] Returns valid PDF for authenticated user (Content-Type: application/pdf)
- [x] Returns 401 without JWT (via `authenticate` middleware at mount)
- [x] All 7 sections included
- [x] Empty states: "No supplements added", "No reactions logged", "No interactions detected"
- [x] Footer on every page
- [x] pdfkit in package.json
- [x] TypeScript compiles with no errors

Closes #60