### PR TITLE
feat: AI research notes on cabinet items

### DIFF
--- a/src/models/CabinetItem.ts
+++ b/src/models/CabinetItem.ts
@@ -3,6 +3,13 @@ import mongoose, { Document, Schema, Types } from 'mongoose';
 export type CabinetItemType = 'supplement' | 'medication' | 'vitamin';
 export type CabinetItemSource = 'user_input' | 'ai_extracted';
 
+export interface IResearchNotes {
+  summary: string;
+  commonDosage: string;
+  cautions: string;
+  generatedAt: Date;
+}
+
 export interface ICabinetItem extends Document {
   userId: Types.ObjectId;
   name: string;
@@ -18,6 +25,7 @@ export interface ICabinetItem extends Document {
   source: CabinetItemSource;
   price?: number;
   currency?: string;
+  researchNotes?: IResearchNotes;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -84,6 +92,18 @@ const CabinetItemSchema = new Schema<ICabinetItem>(
       type: String,
       trim: true,
       default: 'HKD',
+    },
+    researchNotes: {
+      type: new Schema(
+        {
+          summary: { type: String, required: true },
+          commonDosage: { type: String, required: true },
+          cautions: { type: String, required: true },
+          generatedAt: { type: Date, required: true },
+        },
+        { _id: false }
+      ),
+      default: undefined,
     },
   },
   { timestamps: true }

--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -28,6 +28,52 @@ const getGenAI = () => {
 
 const router = Router();
 
+// ─── Research notes helper ────────────────────────────────────────────────────
+
+async function generateResearchNotes(itemId: string, name: string, type: string): Promise<void> {
+  try {
+    const prompt = `You are a evidence-based health advisor. Provide a concise research summary for the supplement or medication below.
+
+Name: ${name}
+Type: ${type}
+
+Return ONLY valid JSON (no markdown fences):
+{
+  "summary": string,       // 2-3 sentences: what it does, key benefits
+  "commonDosage": string,  // e.g. "500–1000mg daily with meals"
+  "cautions": string       // e.g. "Avoid if on blood thinners. Consult a doctor if pregnant."
+}
+
+Important: Include a note that this is general information, not personalised medical advice.`;
+
+    const model = getGenAI().getGenerativeModel({ model: MODELS.CHAT });
+    const result = await model.generateContent(prompt);
+
+    const text = result.response.text().trim();
+    const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+
+    const parsed = JSON.parse(cleaned) as {
+      summary: string;
+      commonDosage: string;
+      cautions: string;
+    };
+
+    await CabinetItem.findByIdAndUpdate(itemId, {
+      researchNotes: {
+        summary: parsed.summary,
+        commonDosage: parsed.commonDosage,
+        cautions: parsed.cautions,
+        generatedAt: new Date(),
+      },
+    });
+
+    console.log(`[AI] research notes generated for item ${itemId} (${name})`);
+  } catch (err) {
+    // Non-fatal — item creation is not affected
+    console.error(`[AI] research notes generation failed for ${name}:`, err);
+  }
+}
+
 // POST /cabinet — add item
 router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
   const ownerId = new Types.ObjectId(req.userId);
@@ -72,6 +118,9 @@ router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
     data: { ...item.toObject(), interactions: [] },
     error: null,
   });
+
+  // Fire-and-forget research notes generation (non-blocking)
+  void generateResearchNotes((item._id as Types.ObjectId).toString(), item.name, item.type);
 });
 
 // GET /cabinet — list user's items with optional filters
@@ -162,6 +211,7 @@ router.put('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
     }
   }
 
+  const nameChanged = updates.name !== undefined && updates.name !== item.name;
   const updated = await CabinetItem.findByIdAndUpdate(id, { $set: updates }, { new: true, runValidators: true });
 
   res.json({
@@ -169,6 +219,37 @@ router.put('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
     data: { ...updated!.toObject(), interactions: [] },
     error: null,
   });
+
+  // Regenerate research notes if name changed (fire-and-forget)
+  if (nameChanged) {
+    void generateResearchNotes(id, updated!.name, updated!.type);
+  }
+});
+
+// POST /cabinet/:id/refresh-research — manually trigger research notes regeneration
+router.post('/:id/refresh-research', async (req: AuthRequest, res: Response): Promise<void> => {
+  const id = req.params['id'] as string;
+
+  if (!Types.ObjectId.isValid(id)) {
+    res.status(400).json({ success: false, data: null, error: 'Invalid item id' });
+    return;
+  }
+
+  const item = await CabinetItem.findById(id);
+  if (!item) {
+    res.status(404).json({ success: false, data: null, error: 'Item not found' });
+    return;
+  }
+
+  if (item.userId.toString() !== req.userId) {
+    res.status(403).json({ success: false, data: null, error: 'Forbidden' });
+    return;
+  }
+
+  res.status(202).json({ success: true, data: { message: 'Research notes regeneration queued.' }, error: null });
+
+  // Fire-and-forget
+  void generateResearchNotes(id, item.name, item.type);
 });
 
 // DELETE /cabinet/:id — soft delete (set active=false + endDate=now)


### PR DESCRIPTION
## What
- `src/models/CabinetItem.ts` — added `IResearchNotes` interface and optional `researchNotes` subdocument field to `CabinetItemSchema`
- `src/routes/cabinet.ts` — added `generateResearchNotes(itemId, name, type)` helper that calls Gemini and saves result back to item (non-blocking, errors swallowed); wired into:
  - `POST /cabinet` — fire-and-forget after `res.status(201)` is sent
  - `PUT /cabinet/:id` — regenerates if `name` changed
  - `POST /cabinet/:id/refresh-research` — manual regeneration endpoint, returns 202 immediately

## Acceptance Criteria
- [x] `researchNotes` optional field in CabinetItem schema with summary, commonDosage, cautions, generatedAt
- [x] POST /cabinet triggers async notes generation after response is sent
- [x] PUT /cabinet/:id regenerates if name changed
- [x] POST /:id/refresh-research returns 202 + triggers regeneration
- [x] AI failure leaves researchNotes null — item creation not affected
- [x] GET /cabinet includes researchNotes in response (null if not yet generated)
- [x] TypeScript compiles with no errors

Closes #61