### PR TITLE
Add GET /cabinet/cycle-alerts endpoint

### DIFF
--- a/src/models/CabinetItem.ts
+++ b/src/models/CabinetItem.ts
@@ -26,6 +26,9 @@ export interface ICabinetItem extends Document {
   price?: number;
   currency?: string;
   researchNotes?: IResearchNotes;
+  quantityRemaining?: number;
+  dailyDoseCount?: number;
+  restockThresholdDays?: number;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -105,6 +108,9 @@ const CabinetItemSchema = new Schema<ICabinetItem>(
       ),
       default: undefined,
     },
+    quantityRemaining: { type: Number, min: 0 },
+    dailyDoseCount: { type: Number, min: 0 },
+    restockThresholdDays: { type: Number, min: 0 },
   },
   { timestamps: true }
 );

--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -1081,4 +1081,64 @@ Rules:
   }
 });
 
+// GET /cabinet/cycle-alerts — AI-recommended cycling alerts for long-running supplements
+router.get('/cycle-alerts', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId;
+    if (!userId) { res.status(401).json({ success: false, data: null, error: 'Unauthorized' }); return; }
+
+    const items = await CabinetItem.find({ userId, active: true }).lean();
+    if (items.length === 0) {
+      res.json({ success: true, data: { alerts: [] } });
+      return;
+    }
+
+    const now = Date.now();
+    const supplementList = items.map((item) => {
+      const daysTaken = Math.floor((now - new Date(item.createdAt as Date).getTime()) / 86400000);
+      return { id: String(item._id), name: item.name, type: item.type, daysTaken };
+    });
+
+    const prompt = `You are an evidence-based health advisor reviewing a user's supplement and medication history.
+The user has been taking the following for the indicated number of days:
+
+${supplementList.map((s) => `- ${s.name} (${s.type}): ${s.daysTaken} days`).join('\n')}
+
+Identify ONLY the items where cycling off is genuinely recommended based on established evidence (e.g. tolerance build-up, safety limits, typical cycle protocols). Ignore items with no known cycling concerns.
+
+Return ONLY valid JSON (no markdown fences):
+{
+  "alerts": [
+    {
+      "id": "<same id as input>",
+      "name": "<supplement name>",
+      "daysTaken": <number>,
+      "recommendation": "<concise action, e.g. 'Consider a 1–2 week break'>",
+      "reason": "<1–2 sentence evidence-based rationale>"
+    }
+  ]
+}
+
+If no items need cycling attention, return { "alerts": [] }.
+This is general information, not personalised medical advice.`;
+
+    const model = getGenAI().getGenerativeModel({ model: MODELS.CHAT });
+    const result = await model.generateContent(prompt);
+    const usage = result.response.usageMetadata;
+    console.log(
+      `[AI] model=${MODELS.CHAT} input_tokens=${usage?.promptTokenCount} output_tokens=${usage?.candidatesTokenCount} task=cycle-alerts`
+    );
+
+    let raw = result.response.text().trim();
+    if (raw.startsWith('```')) raw = raw.replace(/^```[a-z]*\n?/, '').replace(/\n?```$/, '').trim();
+
+    const parsed = JSON.parse(raw) as { alerts: Array<{ id: string; name: string; daysTaken: number; recommendation: string; reason: string }> };
+
+    res.json({ success: true, data: parsed });
+  } catch (err) {
+    console.error('[GET /cabinet/cycle-alerts]', err);
+    res.status(500).json({ success: false, data: null, error: 'Cycle alerts failed' });
+  }
+});
+
 export default router;

--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -155,11 +155,22 @@ router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
     }
   }
 
-  const items = await CabinetItem.find(query).sort({ createdAt: -1 });
+  const items = await CabinetItem.find(query).sort({ createdAt: -1 }).lean();
+
+  const itemsWithComputed = items.map((item) => {
+    const threshold = item.restockThresholdDays ?? 7;
+    let daysSupplyRemaining: number | null = null;
+    let lowSupplyWarning = false;
+    if (item.quantityRemaining != null && item.dailyDoseCount != null && item.dailyDoseCount > 0) {
+      daysSupplyRemaining = Math.floor(item.quantityRemaining / item.dailyDoseCount);
+      lowSupplyWarning = daysSupplyRemaining <= threshold;
+    }
+    return { ...item, daysSupplyRemaining, lowSupplyWarning };
+  });
 
   res.json({
     success: true,
-    data: items,
+    data: itemsWithComputed,
     error: null,
   });
 });
@@ -184,7 +195,7 @@ router.put('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
     return;
   }
 
-  const allowedFields = ['name', 'type', 'dosage', 'frequency', 'timing', 'brand', 'notes', 'active', 'startDate', 'endDate', 'source', 'price', 'currency'] as const;
+  const allowedFields = ['name', 'type', 'dosage', 'frequency', 'timing', 'brand', 'notes', 'active', 'startDate', 'endDate', 'source', 'price', 'currency', 'quantityRemaining', 'dailyDoseCount', 'restockThresholdDays'] as const;
   type AllowedField = typeof allowedFields[number];
 
   const validTypes: CabinetItemType[] = ['supplement', 'medication', 'vitamin'];
@@ -770,6 +781,34 @@ ${items.map((i) => `- id: ${(i._id as Types.ObjectId).toString()} | name: ${i.na
     console.error('[GET /cabinet/schedule/optimized]', err);
     res.status(500).json({ success: false, data: null, error: 'Schedule optimization failed' });
   }
+});
+
+// GET /cabinet/restock-alerts — items with low supply warning
+router.get('/restock-alerts', async (req: AuthRequest, res: Response): Promise<void> => {
+  const ownerId = new Types.ObjectId(req.userId);
+  const scopedUserId = await resolveScopedUserId(ownerId, req.query.memberId as string | undefined);
+  if (!scopedUserId) {
+    res.status(404).json({ success: false, data: null, error: 'Family member not found' });
+    return;
+  }
+
+  const items = await CabinetItem.find({ userId: scopedUserId, active: true }).lean();
+
+  const alerts = items
+    .filter((item) => {
+      if (item.quantityRemaining == null || item.dailyDoseCount == null || item.dailyDoseCount <= 0) return false;
+      const daysSupply = Math.floor(item.quantityRemaining / item.dailyDoseCount);
+      const threshold = item.restockThresholdDays ?? 7;
+      return daysSupply <= threshold;
+    })
+    .map((item) => ({
+      id: (item._id as Types.ObjectId).toString(),
+      name: item.name,
+      daysSupplyRemaining: Math.floor(item.quantityRemaining! / item.dailyDoseCount!),
+      quantityRemaining: item.quantityRemaining!,
+    }));
+
+  res.json({ success: true, data: { alerts }, error: null });
 });
 
 // GET /cabinet/schedule — group active items by time-of-day slot


### PR DESCRIPTION
## Summary
- Adds `GET /cabinet/cycle-alerts` route to `src/routes/cabinet.ts`
- Computes `daysTaken` per active cabinet item from `createdAt`
- Calls Gemini with supplement list + days taken, asks for evidence-based cycling recommendations
- Returns `{ success, data: { alerts: [{ id, name, daysTaken, recommendation, reason }] } }`
- Returns empty alerts array if no items warrant cycling attention

Closes #72

## Test plan
- [ ] Authenticated GET /cabinet/cycle-alerts returns 200
- [ ] With a long-running supplement (e.g. Caffeine 70+ days), alert is returned
- [ ] With fresh items or no cycling concerns, alerts array is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)