### PR TITLE
Add daily journal model and POST/GET /journal endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import familyMembersRouter from './routes/familyMembers';
 import wellnessRouter from './routes/wellness';
 import sideEffectsRouter from './routes/sideEffects';
 import exportRouter from './routes/export';
+import journalRouter from './routes/journal';
 import { authenticate } from './middleware/auth';
 
 dotenv.config();
@@ -40,6 +41,7 @@ app.use('/family-members', familyMembersRouter);
 app.use('/wellness', authenticate, wellnessRouter);
 app.use('/side-effects', authenticate, sideEffectsRouter);
 app.use('/export', authenticate, exportRouter);
+app.use('/journal', journalRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/models/DailyLog.ts
+++ b/src/models/DailyLog.ts
@@ -1,0 +1,24 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IDailyLog extends Document {
+  userId: Types.ObjectId;
+  date: string; // YYYY-MM-DD
+  mood: number; // 1-5
+  energy: number; // 1-5
+  notes?: string;
+  createdAt: Date;
+}
+
+const DailyLogSchema = new Schema<IDailyLog>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    date: { type: String, required: true },
+    mood: { type: Number, required: true, min: 1, max: 5 },
+    energy: { type: Number, required: true, min: 1, max: 5 },
+    notes: { type: String, maxlength: 500 },
+  },
+  { timestamps: true }
+);
+DailyLogSchema.index({ userId: 1, date: 1 }, { unique: true });
+
+export const DailyLog = model<IDailyLog>('DailyLog', DailyLogSchema);

--- a/src/routes/journal.ts
+++ b/src/routes/journal.ts
@@ -1,0 +1,125 @@
+import { Router, Response } from 'express';
+import { Types } from 'mongoose';
+import { authenticate, AuthRequest } from '../middleware/auth';
+import { DailyLog } from '../models/DailyLog';
+
+const router = Router();
+
+router.use(authenticate);
+
+/**
+ * POST /journal
+ * Upsert a daily log entry for the authenticated user.
+ * Body: { date?, mood, energy, notes? }
+ */
+router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId;
+  if (!userId) {
+    res.status(401).json({ success: false, data: null, error: 'Unauthorized' });
+    return;
+  }
+
+  const { mood, energy, notes } = req.body;
+  let { date } = req.body;
+
+  // Default to today's date if not provided
+  if (!date) {
+    date = new Date().toISOString().slice(0, 10);
+  }
+
+  // Validate date format YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    res.status(400).json({ success: false, data: null, error: 'date must be in YYYY-MM-DD format' });
+    return;
+  }
+
+  // Validate mood
+  if (mood === undefined || mood === null) {
+    res.status(400).json({ success: false, data: null, error: 'mood is required' });
+    return;
+  }
+  const moodNum = Number(mood);
+  if (!Number.isInteger(moodNum) || moodNum < 1 || moodNum > 5) {
+    res.status(400).json({ success: false, data: null, error: 'mood must be an integer between 1 and 5' });
+    return;
+  }
+
+  // Validate energy
+  if (energy === undefined || energy === null) {
+    res.status(400).json({ success: false, data: null, error: 'energy is required' });
+    return;
+  }
+  const energyNum = Number(energy);
+  if (!Number.isInteger(energyNum) || energyNum < 1 || energyNum > 5) {
+    res.status(400).json({ success: false, data: null, error: 'energy must be an integer between 1 and 5' });
+    return;
+  }
+
+  // Validate notes length if provided
+  if (notes !== undefined && notes !== null && typeof notes === 'string' && notes.length > 500) {
+    res.status(400).json({ success: false, data: null, error: 'notes must not exceed 500 characters' });
+    return;
+  }
+
+  try {
+    const updateFields: { mood: number; energy: number; notes?: string } = {
+      mood: moodNum,
+      energy: energyNum,
+    };
+    if (notes !== undefined && notes !== null) {
+      updateFields.notes = String(notes);
+    }
+
+    const entry = await DailyLog.findOneAndUpdate(
+      { userId: new Types.ObjectId(userId), date },
+      { $set: updateFields },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+
+    res.json({ success: true, data: entry, error: null });
+  } catch (err) {
+    console.error('[POST /journal] error:', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to save journal entry' });
+  }
+});
+
+/**
+ * GET /journal
+ * Return journal entries for the authenticated user over the last N days.
+ * Query: ?days=30 (default 30, max 90)
+ */
+router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId;
+  if (!userId) {
+    res.status(401).json({ success: false, data: null, error: 'Unauthorized' });
+    return;
+  }
+
+  let days = 30;
+  if (req.query.days !== undefined) {
+    const parsed = Number(req.query.days);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      res.status(400).json({ success: false, data: null, error: 'days must be a positive integer' });
+      return;
+    }
+    days = Math.min(parsed, 90);
+  }
+
+  try {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    const cutoffDate = cutoff.toISOString().slice(0, 10);
+
+    const entries = await DailyLog.find({
+      userId: new Types.ObjectId(userId),
+      date: { $gte: cutoffDate },
+    }).sort({ date: -1 });
+
+    res.json({ success: true, data: entries, error: null });
+  } catch (err) {
+    console.error('[GET /journal] error:', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to fetch journal entries' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## What
- Added `src/models/DailyLog.ts` — Mongoose schema with `userId`, `date` (YYYY-MM-DD), `mood` (1–5), `energy` (1–5), `notes` (optional, max 500 chars), unique compound index on `{ userId, date }`
- Added `src/routes/journal.ts` — `POST /journal` (upsert with validation) and `GET /journal` (last N days, max 90, sorted by date desc), auth applied via `authenticate` middleware
- Registered router in `src/index.ts` as `app.use('/journal', journalRouter)`

## Why
Closes #80

## Acceptance Criteria
- [x] `DailyLog` model created with correct fields and unique index
- [x] `POST /journal` upserts entry, validates mood/energy as 1–5 integers, defaults date to today
- [x] `GET /journal` returns entries for last N days (default 30, max 90), sorted by date desc
- [x] Auth required on both endpoints
- [x] `tsc --noEmit` passes with zero errors
- [x] Only 3 files changed: `DailyLog.ts`, `journal.ts`, `index.ts`

## Test Plan
1. `POST /journal` with valid body `{ mood: 3, energy: 4 }` — expect 200 with today's date entry
2. `POST /journal` same date again with different values — expect updated entry (upsert)
3. `POST /journal` with `mood: 6` — expect 400 validation error
4. `GET /journal?days=7` — expect entries from last 7 days sorted by date desc
5. `GET /journal?days=100` — expect clamped to 90 days
6. Both endpoints without auth token — expect 401