### PR TITLE
Add BloodworkEntry model and bloodwork endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import wellnessRouter from './routes/wellness';
 import sideEffectsRouter from './routes/sideEffects';
 import exportRouter from './routes/export';
 import journalRouter from './routes/journal';
+import { bloodworkRouter } from './routes/bloodwork';
 import { authenticate } from './middleware/auth';
 
 dotenv.config();
@@ -42,6 +43,7 @@ app.use('/wellness', authenticate, wellnessRouter);
 app.use('/side-effects', authenticate, sideEffectsRouter);
 app.use('/export', authenticate, exportRouter);
 app.use('/journal', journalRouter);
+app.use('/bloodwork', bloodworkRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/models/BloodworkEntry.ts
+++ b/src/models/BloodworkEntry.ts
@@ -1,0 +1,25 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IBloodworkEntry extends Document {
+  userId: Types.ObjectId;
+  date: string; // YYYY-MM-DD
+  marker: string;
+  value: number;
+  unit: string;
+  createdAt: Date;
+}
+
+const BloodworkEntrySchema = new Schema<IBloodworkEntry>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    date: { type: String, required: true },
+    marker: { type: String, required: true, trim: true },
+    value: { type: Number, required: true },
+    unit: { type: String, required: true, trim: true },
+  },
+  { timestamps: true },
+);
+
+BloodworkEntrySchema.index({ userId: 1, marker: 1, date: 1 });
+
+export const BloodworkEntry = model<IBloodworkEntry>('BloodworkEntry', BloodworkEntrySchema);

--- a/src/routes/bloodwork.ts
+++ b/src/routes/bloodwork.ts
@@ -1,0 +1,72 @@
+import { Router, Response } from 'express';
+import { authenticate, AuthRequest } from '../middleware/auth';
+import { BloodworkEntry } from '../models/BloodworkEntry';
+
+const router = Router();
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+// POST /bloodwork — create a new bloodwork entry
+router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    const { date, marker, value, unit } = req.body as {
+      date: unknown;
+      marker: unknown;
+      value: unknown;
+      unit: unknown;
+    };
+
+    if (typeof date !== 'string' || !DATE_REGEX.test(date)) {
+      res.status(400).json({ error: 'date must be a valid YYYY-MM-DD string' });
+      return;
+    }
+
+    if (typeof marker !== 'string' || marker.trim().length === 0) {
+      res.status(400).json({ error: 'marker must be a non-empty string' });
+      return;
+    }
+
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      res.status(400).json({ error: 'value must be a number' });
+      return;
+    }
+
+    if (typeof unit !== 'string' || unit.trim().length === 0) {
+      res.status(400).json({ error: 'unit must be a non-empty string' });
+      return;
+    }
+
+    const entry = await BloodworkEntry.create({
+      userId: req.userId,
+      date,
+      marker: marker.trim(),
+      value,
+      unit: unit.trim(),
+    });
+
+    res.status(201).json({ success: true, data: entry });
+  } catch (error) {
+    console.error('Bloodwork POST error:', error);
+    res.status(500).json({ error: 'Failed to save bloodwork entry' });
+  }
+});
+
+// GET /bloodwork — list all entries for the user, optionally filtered by marker
+router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    const filter: { userId: string | undefined; marker?: string } = { userId: req.userId };
+
+    if (typeof req.query.marker === 'string' && req.query.marker.length > 0) {
+      filter.marker = req.query.marker;
+    }
+
+    const entries = await BloodworkEntry.find(filter).sort({ date: 1 });
+
+    res.json({ success: true, data: entries });
+  } catch (error) {
+    console.error('Bloodwork GET error:', error);
+    res.status(500).json({ error: 'Failed to retrieve bloodwork entries' });
+  }
+});
+
+export { router as bloodworkRouter };


### PR DESCRIPTION
## Summary
- `BloodworkEntry` Mongoose model with compound index on `{ userId, marker, date }`
- `POST /bloodwork` — validates and saves a new lab result
- `GET /bloodwork` — returns all user entries sorted by date asc, optional `?marker=` filter
- Registered under `/bloodwork` in `src/index.ts`

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)