### PR TITLE
fix: add bloodwork to empty profile shell for new users

### DIFF
--- a/src/routes/profile.ts
+++ b/src/routes/profile.ts
@@ -105,6 +105,7 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response): Promise<v
         sleep: {},
         lifestyle: {},
         goals: {},
+        bloodwork: {},
         changeHistory: [],
       },
       error: null,


### PR DESCRIPTION
## Summary

When a new user has no profile in the DB, `GET /profile` returns an empty shell. This shell was missing `bloodwork: {}`, causing the frontend to crash when rendering the Bloodwork category section.

## Change

Added `bloodwork: {}` to the new-user profile shell response in `src/routes/profile.ts`.

## Test plan
- [ ] `GET /profile` for a user with no profile → response includes `bloodwork: {}`
- [ ] Existing users with a bloodwork field: no regression

Closes related issue for new user crash (recallth-web#114)

🤖 Generated with [Claude Code](https://claude.com/claude-code)