### PR TITLE
feat: auto-generate conversation title and summary after first exchange

### DIFF
--- a/src/models/Conversation.ts
+++ b/src/models/Conversation.ts
@@ -11,6 +11,7 @@ export interface IMessage {
 export interface IConversation extends Document {
   userId: Types.ObjectId;
   title: string;
+  summary: string;
   messages: IMessage[];
   createdAt: Date;
   updatedAt: Date;
@@ -29,6 +30,7 @@ const ConversationSchema = new Schema<IConversation>(
   {
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     title: { type: String, required: true, default: 'New Conversation' },
+    summary: { type: String, default: '' },
     messages: [MessageSchema],
   },
   { timestamps: true }

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -87,6 +87,7 @@ chatRouter.get('/history', async (req: AuthRequest, res: Response): Promise<void
       $project: {
         _id: 1,
         title: 1,
+        summary: 1,
         createdAt: 1,
         messageCount: { $size: '$messages' },
       },

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -358,11 +358,33 @@ async function applyExtractedData(
   }
 }
 
-// --- Generate title from first message ---
+// --- Generate title from first message (fallback) ---
 function generateTitle(message: string): string {
   const trimmed = message.trim();
-  if (trimmed.length <= 50) return trimmed;
-  return trimmed.slice(0, 47) + '...';
+  if (trimmed.length <= 60) return trimmed;
+  return trimmed.slice(0, 57) + '...';
+}
+
+// --- AI-generated title + summary after first exchange ---
+async function generateTitleAndSummary(
+  conversationId: string,
+  firstUserMessage: string
+): Promise<void> {
+  try {
+    const prompt = `Given this user question: "${firstUserMessage.slice(0, 500)}", write a conversation title in 6–8 words and a one-sentence summary. Return JSON only, no markdown: {"title": "...", "summary": "..."}`;
+    const model = getGenAI().getGenerativeModel({ model: MODELS.EXTRACTION });
+    const result = await model.generateContent(prompt);
+    const text = result.response.text().trim();
+    const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+    const parsed = JSON.parse(cleaned) as { title?: string; summary?: string };
+    const title = (parsed.title ?? '').slice(0, 80).trim();
+    const summary = (parsed.summary ?? '').slice(0, 200).trim();
+    if (title) {
+      await Conversation.findByIdAndUpdate(conversationId, { title, summary });
+    }
+  } catch (err) {
+    console.error('[Chat] Title generation error (non-fatal):', err);
+  }
 }
 
 // --- Parse suggestions JSON block from AI response ---
@@ -478,6 +500,11 @@ export async function processChat(
   };
   conversation.messages.push(assistantMsg);
   await conversation.save();
+
+  // Fire async title+summary generation after first exchange (non-blocking)
+  if (conversation.messages.length === 2 && !conversationId) {
+    void generateTitleAndSummary(String(conversation._id), userMessage);
+  }
 
   // Run extraction in parallel (non-blocking on response, but we await to include in response)
   let extractedData: ExtractionResult | null = null;


### PR DESCRIPTION
## Summary
- Adds `summary` field to Conversation schema (default `""`)
- After the first exchange in a new conversation, fires an async (non-blocking) Gemini call to generate a meaningful 6–8 word title and one-sentence summary
- `GET /chat/history` now returns `title` and `summary` per conversation entry
- `GET /chat/:conversationId` returns `summary` automatically via full document response
- Title generation failure does not crash the chat endpoint — falls back gracefully to the truncated user message as title
- Existing conversations without a generated title/summary return `title: "New Conversation"` and `summary: ""`

## Test plan
- [ ] Send a new chat message → verify conversation created with fallback title
- [ ] After first exchange completes, query `GET /chat/history` → verify `title` and `summary` are populated with AI-generated values
- [ ] Query `GET /chat/:conversationId` → verify `summary` field present
- [ ] Verify chat response latency is not affected (title generation is fire-and-forget)
- [ ] Verify existing conversations without summary return `summary: ""` (no breaking change)

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)