### PR TITLE
feat: POST /insights/journal-insights with 24h cache (#158)

### DIFF
--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -236,8 +236,7 @@ router.post('/journal-insights', async (req: AuthRequest, res: Response): Promis
       const parts = [`${d}: mood=${l.mood ?? '?'}/5 energy=${l.energy ?? '?'}/5`];
       if (l.notes) parts.push(`notes="${l.notes.slice(0, 80)}"`);
       return parts.join(' ');
-    }).join('
-');
+    }).join('\n');
 
     const cabinetText = cabinet.length > 0
       ? cabinet.map((c) => `${c.name}${c.dosage ? ` ${c.dosage}` : ''}${c.frequency ? ` (${c.frequency})` : ''}`).join(', ')

--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -179,4 +179,113 @@ This is general health information, not personalised medical advice.`;
   }
 });
 
+
+const JOURNAL_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const JOURNAL_INSIGHTS_TYPE = 'journal-insights';
+
+// POST /insights/journal-insights
+// Returns cached insights if fresh (<24h), otherwise generates new ones.
+router.post('/journal-insights', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId;
+    if (!userId) { res.status(401).json({ success: false, data: null, error: 'Unauthorized' }); return; }
+
+    const userObjectId = new Types.ObjectId(userId);
+    const forceRefresh = (req.body as { forceRefresh?: boolean })?.forceRefresh === true;
+
+    // Check cache
+    const cached = await InsightCache.findOne({ userId: userObjectId, type: JOURNAL_INSIGHTS_TYPE }).lean();
+    const now = Date.now();
+    const isFresh = cached && (now - cached.generatedAt.getTime()) < JOURNAL_TTL_MS;
+
+    if (isFresh && !forceRefresh) {
+      let insights: string[] = [];
+      try { insights = JSON.parse(cached.content) as string[]; } catch { insights = [cached.content]; }
+      res.json({ success: true, data: { insights, generatedAt: cached.generatedAt.toISOString(), fromCache: true }, error: null });
+      return;
+    }
+
+    if (forceRefresh && cached && isFresh) {
+      const ageMs = now - cached.generatedAt.getTime();
+      const retryAfterMs = JOURNAL_TTL_MS - ageMs;
+      let insights: string[] = [];
+      try { insights = JSON.parse(cached.content) as string[]; } catch { insights = [cached.content]; }
+      res.status(429).json({
+        success: false,
+        data: { insights, generatedAt: cached.generatedAt.toISOString(), retryAfterMs },
+        error: 'Rate limited — try again later',
+      });
+      return;
+    }
+
+    // Fetch last 30 days of journal entries
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const [logs, cabinet] = await Promise.all([
+      DailyLog.find({ userId: userObjectId, date: { $gte: thirtyDaysAgo } }).sort({ date: 1 }).lean(),
+      CabinetItem.find({ userId: userObjectId, active: true }).lean(),
+    ]);
+
+    // Minimum data check: 5 entries required
+    if (logs.length < 5) {
+      res.json({ success: true, data: { insights: [], generatedAt: new Date().toISOString(), insufficientData: true }, error: null });
+      return;
+    }
+
+    const journalSummary = logs.map((l) => {
+      const d = new Date(l.date).toISOString().slice(0, 10);
+      const parts = [`${d}: mood=${l.mood ?? '?'}/5 energy=${l.energy ?? '?'}/5`];
+      if (l.notes) parts.push(`notes="${l.notes.slice(0, 80)}"`);
+      return parts.join(' ');
+    }).join('
+');
+
+    const cabinetText = cabinet.length > 0
+      ? cabinet.map((c) => `${c.name}${c.dosage ? ` ${c.dosage}` : ''}${c.frequency ? ` (${c.frequency})` : ''}`).join(', ')
+      : 'None';
+
+    const prompt = `You are a health pattern analyst. Analyse the following journal data and return 2–3 specific, plain-language observations.
+
+Journal entries (last 30 days):
+${journalSummary}
+
+Active supplements: ${cabinetText}
+
+Rules:
+- Each insight must reference specific data (e.g. dates, score values, supplement names)
+- Do NOT make diagnoses or medical claims
+- Keep each insight to 1–2 sentences
+- Return ONLY valid JSON array of strings, no markdown:
+["insight 1", "insight 2", "insight 3"]`;
+
+    const model = getGenAI().getGenerativeModel({ model: MODELS.CHAT });
+    const result = await model.generateContent(prompt);
+    const text = result.response.text().trim();
+    const cleaned = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim();
+
+    let insights: string[];
+    try {
+      insights = JSON.parse(cleaned) as string[];
+      if (!Array.isArray(insights)) throw new Error('not array');
+      insights = insights.filter((s) => typeof s === 'string' && s.trim()).slice(0, 3);
+    } catch {
+      insights = [cleaned];
+    }
+
+    const generatedAt = new Date();
+    await InsightCache.findOneAndUpdate(
+      { userId: userObjectId, type: JOURNAL_INSIGHTS_TYPE },
+      { content: JSON.stringify(insights), generatedAt },
+      { upsert: true, new: true }
+    );
+
+    const usage = result.response.usageMetadata;
+    console.log(`[AI] model=${MODELS.CHAT} input_tokens=${usage?.promptTokenCount} output_tokens=${usage?.candidatesTokenCount} task=journal-insights`);
+
+    res.json({ success: true, data: { insights, generatedAt: generatedAt.toISOString(), fromCache: false }, error: null });
+  } catch (err) {
+    console.error('[POST /insights/journal-insights]', err);
+    res.status(500).json({ success: false, data: null, error: 'Journal insights generation failed' });
+  }
+});
+
 export { router as insightsRouter };

--- a/src/routes/insights.ts
+++ b/src/routes/insights.ts
@@ -219,7 +219,7 @@ router.post('/journal-insights', async (req: AuthRequest, res: Response): Promis
     }
 
     // Fetch last 30 days of journal entries
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
     const [logs, cabinet] = await Promise.all([
       DailyLog.find({ userId: userObjectId, date: { $gte: thirtyDaysAgo } }).sort({ date: 1 }).lean(),
       CabinetItem.find({ userId: userObjectId, active: true }).lean(),


### PR DESCRIPTION
## Summary
- `POST /insights/journal-insights` added to `insights.ts`
- Fetches last 30 days of journal entries + active cabinet items
- Returns `{ insights: string[], generatedAt, fromCache, insufficientData? }`
- 24h TTL via `InsightCache` model (type: `'journal-insights'`)
- `forceRefresh: true` triggers re-generation; rate-limited if cache is still fresh → 429 with `retryAfterMs`
- Minimum data guard: < 5 entries → returns `{ insufficientData: true }`

## Test plan
- [ ] POST with < 5 entries → `{ insufficientData: true }`
- [ ] POST with ≥ 5 entries → 2–3 string insights, cached in InsightCache
- [ ] Second POST (no force) → fromCache: true, no AI call
- [ ] POST forceRefresh within 24h → 429 with retryAfterMs
- [ ] Unauthenticated → 401

Closes #158 (backend part)

🤖 Generated with [Claude Code](https://claude.com/claude-code)