### PR TITLE
feat(#53): use UI language override in chat endpoint

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -22,9 +22,10 @@ chatRouter.use(authenticate);
 // POST /chat — send message, get AI response
 chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
   const userId = req.userId as string;
-  const { message, conversationId } = req.body as {
+  const { message, conversationId, language } = req.body as {
     message?: string;
     conversationId?: string;
+    language?: string;
   };
 
   if (!message || typeof message !== 'string' || message.trim().length === 0) {
@@ -56,7 +57,9 @@ chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
     return;
   }
 
-  const result = await processChat(userId, message.trim(), conversationId);
+  const validLanguages = ['en', 'zh-HK', 'zh-TW'];
+  const languageOverride = language && validLanguages.includes(language) ? language as 'en' | 'zh-HK' | 'zh-TW' : undefined;
+  const result = await processChat(userId, message.trim(), conversationId, languageOverride);
 
   res.status(200).json({
     success: true,

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -452,12 +452,13 @@ export interface ChatResult {
 export async function processChat(
   userId: string,
   userMessage: string,
-  conversationId?: string
+  conversationId?: string,
+  languageOverride?: DetectedLanguage
 ): Promise<ChatResult> {
   const userObjectId = new Types.ObjectId(userId);
 
-  // Detect language from user message
-  const language = detectLanguage(userMessage);
+  // Use UI language override if provided, otherwise detect from message
+  const language = languageOverride ?? detectLanguage(userMessage);
 
   // Load profile, cabinet, journal, and side effects in parallel
   const sevenDaysAgo = new Date();


### PR DESCRIPTION
## Summary
- Accept optional `language` field in `POST /chat` request body (`en`, `zh-HK`, `zh-TW`)
- If provided and valid, pass as `languageOverride` to `processChat()` — bypasses `detectLanguage()`
- Ensures AI responds in the user's chosen UI language, not the auto-detected message language

Closes #53

## Test plan
- [ ] Send a message in English with `language: "zh-HK"` → AI should respond in Cantonese
- [ ] Send a message without `language` field → auto-detection still works
- [ ] Send an invalid language value → treated as no override

🤖 Generated with [Claude Code](https://claude.com/claude-code)