### PR TITLE
fix: strip hallucinated imageUrl from ai-lookup response

### DIFF
--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -935,10 +935,9 @@ Return up to 3 matching supplement or health product results as a JSON array. Ea
 - timing: one of "Morning", "Pre-workout", "With meals", "Evening", "Before bed" (string, required)
 - description: 1-2 sentence product description (string, required)
 - ingredients: key active ingredients e.g. "Whey Protein Isolate, Whey Protein Concentrate" (string, required)
-- imageUrl: a real, publicly accessible product image URL if you know one with confidence (e.g. from the brand's official CDN, iHerb, or a major retailer). If unsure, use "" (string, required)
 
 Return ONLY a valid JSON array, no markdown, no explanation.
-Example: [{"name":"Gold Standard 100% Whey","brand":"Optimum Nutrition","type":"supplement","dosage":"30.4g (1 scoop)","frequency":"Daily","timing":"Post-workout","description":"Premium whey protein blend with 24g of protein per serving.","ingredients":"Whey Protein Isolate, Whey Protein Concentrate, Whey Peptides","imageUrl":"https://www.optimumnutrition.com/..."}]`;
+Example: [{"name":"Gold Standard 100% Whey","brand":"Optimum Nutrition","type":"supplement","dosage":"30.4g (1 scoop)","frequency":"Daily","timing":"Post-workout","description":"Premium whey protein blend with 24g of protein per serving.","ingredients":"Whey Protein Isolate, Whey Protein Concentrate, Whey Peptides"}]`;
 
     const result = await model.generateContent(prompt);
     const text = result.response.text().trim();
@@ -956,7 +955,9 @@ Example: [{"name":"Gold Standard 100% Whey","brand":"Optimum Nutrition","type":"
       return;
     }
 
-    res.json({ success: true, data: products.slice(0, 3), error: null });
+    // Strip imageUrl — LLMs hallucinate image URLs; frontend uses letter placeholder instead
+    const sanitized = products.slice(0, 3).map((p: Record<string, unknown>) => ({ ...p, imageUrl: '' }));
+    res.json({ success: true, data: sanitized, error: null });
   } catch (err) {
     console.error('[POST /cabinet/ai-lookup]', err);
     res.status(500).json({ success: false, data: null, error: 'AI lookup failed' });


### PR DESCRIPTION
## Summary
- Remove `imageUrl` from the `ai-lookup` AI prompt — LLMs cannot generate valid, persistent product image URLs
- Explicitly set `imageUrl: ""` in the response so the frontend always uses its letter placeholder fallback
- No frontend changes needed — fallback already exists

Closes #121

## Test plan
- [ ] Search for a product on `/cabinet/add` AI search
- [ ] Results load with letter placeholders (no broken image icons)
- [ ] No failed network requests for image URLs in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)