### PR TITLE
fix: strict CDN allowlist — only accept confirmed CORS-safe image hosts

### DIFF
--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -918,21 +918,19 @@ function isImageUrl(url: string): boolean {
   if (!url) return false;
   try {
     const u = new URL(url);
-    // Must be https
     if (u.protocol !== 'https:') return false;
-    // Ends in a known image extension
-    if (/\.(jpg|jpeg|png|webp|gif)(\?.*)?$/i.test(u.pathname)) return true;
-    // Known image CDN hostnames
+    // Only accept hostnames that are confirmed to serve CORS-safe images.
+    // Brand website CDNs (pvl.ca, optimumnutrition.com, etc.) block cross-origin
+    // image loads with ERR_BLOCKED_BY_ORB — extension alone is not enough.
     const host = u.hostname;
-    if (
+    return (
       host === 'm.media-amazon.com' ||
       host === 'images-na.ssl-images-amazon.com' ||
       host === 'images.iherb.com' ||
       host === 'images.openfoodfacts.org' ||
       host.endsWith('.cloudinary.com') ||
-      host.endsWith('.shopify.com') && u.pathname.includes('/products/')
-    ) return true;
-    return false;
+      host === 'cdn.shopify.com'
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Problem

PR#126's `isImageUrl` check passed any URL ending in `.jpg/.png` — but brand CDNs like `pvl.ca`, `optimumnutrition.com`, `gnc.com` don't serve CORS headers. The browser blocks them with `ERR_BLOCKED_BY_ORB`.

## Fix

Remove the extension-only check. Only accept URLs from a strict list of hostnames confirmed to be CORS-safe image CDNs:
- `m.media-amazon.com`
- `images-na.ssl-images-amazon.com`  
- `images.iherb.com`
- `images.openfoodfacts.org`
- `*.cloudinary.com`
- `cdn.shopify.com`

All other URLs (brand website CDNs, product page URLs) → Open Food Facts fallback → `""`.

## Result
- Zero ERR_BLOCKED_BY_ORB errors
- AI URLs from allowed CDNs still show images when valid
- Everything else falls back cleanly to letter placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)