### PR TITLE
fix: final safety-net — strip non-allowlisted imageUrls before response

### DIFF
--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -1008,7 +1008,12 @@ Example: [{"name":"Gold Standard 100% Whey","brand":"Optimum Nutrition","type":"
         return { ...p, imageUrl: offUrl };
       })
     );
-    res.json({ success: true, data: enriched, error: null });
+    // Final safety net: strip any imageUrl that slipped through without passing the allowlist
+    const safe = enriched.map((p) => ({
+      ...p,
+      imageUrl: isImageUrl(String(p.imageUrl ?? '')) ? String(p.imageUrl) : '',
+    }));
+    res.json({ success: true, data: safe, error: null });
   } catch (err) {
     console.error('[POST /cabinet/ai-lookup]', err);
     res.status(500).json({ success: false, data: null, error: 'AI lookup failed' });


### PR DESCRIPTION
## Problem

QA still saw non-allowlisted CDN URLs (`nutrabolt.com`, `optimumnutrition.com`, `walmartimages.com`) in the response, causing ERR_BLOCKED_BY_ORB. The primary pipeline check was correct but a deployment lag or edge case allowed URLs through.

## Fix

Add a second `isImageUrl` pass on the final response payload — last line of defence before `res.json()`. Any `imageUrl` that doesn't pass the allowlist at this final step is set to `""`.

This is belt-and-suspenders: the primary pipeline check + this final sanitization means nothing non-allowlisted can ever reach the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)