### PR TITLE
feat: account linking — set-password and link-google endpoints

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,7 +1,9 @@
 import { Router, Request, Response } from 'express';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { OAuth2Client } from 'google-auth-library';
 import { User } from '../models/User';
+import { authenticate, AuthRequest } from '../middleware/auth';
 
 const router = Router();
 const SALT_ROUNDS = 12;
@@ -55,7 +57,7 @@ router.post('/login', async (req: Request, res: Response): Promise<void> => {
   }
 
   if (!user.passwordHash) {
-    res.status(401).json({ success: false, data: null, error: 'This account uses Google Sign-In. Please use "Continue with Google".' });
+    res.status(401).json({ success: false, data: null, error: 'No password set for this account. Please sign in with Google, or set a password in your account settings.' });
     return;
   }
   const valid = await bcrypt.compare(password, user.passwordHash);
@@ -72,6 +74,82 @@ router.post('/login', async (req: Request, res: Response): Promise<void> => {
     data: { token, userId: user._id, email: user.email },
     error: null,
   });
+});
+
+// POST /auth/set-password
+router.post('/set-password', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const { password } = req.body;
+
+  if (!password || typeof password !== 'string') {
+    res.status(400).json({ success: false, data: null, error: 'Password is required' });
+    return;
+  }
+
+  if (password.length < 8) {
+    res.status(400).json({ success: false, data: null, error: 'Password must be at least 8 characters' });
+    return;
+  }
+
+  const user = await User.findById(req.userId);
+  if (!user) {
+    res.status(404).json({ success: false, data: null, error: 'User not found' });
+    return;
+  }
+
+  if (user.passwordHash) {
+    res.status(400).json({ success: false, data: null, error: 'Password already set for this account' });
+    return;
+  }
+
+  user.passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+  await user.save();
+
+  res.json({ success: true, data: null, error: null });
+});
+
+// POST /auth/link-google
+router.post('/link-google', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const { googleToken } = req.body;
+
+  if (!googleToken || typeof googleToken !== 'string') {
+    res.status(400).json({ success: false, data: null, error: 'googleToken is required' });
+    return;
+  }
+
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+  if (!clientId) {
+    res.status(500).json({ success: false, data: null, error: 'Google SSO not configured' });
+    return;
+  }
+
+  const client = new OAuth2Client(clientId);
+  const ticket = await client.verifyIdToken({ idToken: googleToken, audience: clientId });
+  const payload = ticket.getPayload();
+
+  if (!payload || !payload.sub) {
+    res.status(401).json({ success: false, data: null, error: 'Invalid Google token' });
+    return;
+  }
+
+  const googleId = payload.sub;
+
+  // Check if this Google account is already linked to a different user
+  const existingLinked = await User.findOne({ googleId });
+  if (existingLinked && existingLinked._id.toString() !== req.userId) {
+    res.status(409).json({ success: false, data: null, error: 'This Google account is already linked to another user' });
+    return;
+  }
+
+  const user = await User.findById(req.userId);
+  if (!user) {
+    res.status(404).json({ success: false, data: null, error: 'User not found' });
+    return;
+  }
+
+  user.googleId = googleId;
+  await user.save();
+
+  res.json({ success: true, data: null, error: null });
 });
 
 export default router;


### PR DESCRIPTION
## What

Adds two new authenticated endpoints to allow users to link auth methods to an existing account:

- `POST /auth/set-password` — lets a Google-only user add a password to their account. Requires JWT auth. Returns 400 if a password is already set.
- `POST /auth/link-google` — lets an email/password user link a Google account. Requires JWT auth. Returns 409 if the Google ID is already claimed by a different user.
- Updated the `POST /auth/login` error message when `passwordHash` is null to guide the user toward setting a password in account settings.

The `User` model already had `googleId` as an optional field — no model changes required.

## Why

Closes #131

## Acceptance Criteria

- [x] `POST /auth/set-password` requires valid JWT
- [x] Returns 400 if password < 8 characters
- [x] Returns 400 if user already has a password set
- [x] Hashes with bcrypt (SALT\_ROUNDS = 12) and saves
- [x] Returns `{ success: true, data: null, error: null }`
- [x] `POST /auth/link-google` requires valid JWT
- [x] Verifies `googleToken` via `google-auth-library` (same pattern as `authGoogle.ts`)
- [x] Returns 409 if that Google account is already linked to a different user
- [x] Saves `googleId` on the current user
- [x] Returns `{ success: true, data: null, error: null }`
- [x] `POST /auth/login` error message updated when no password set

## Test Plan

1. Register an email/password user → get token
2. `POST /auth/set-password` with that token and `{ "password": "newpass123" }` → 200 success
3. Attempt again → 400 "Password already set"
4. Attempt with `{ "password": "short" }` → 400 "at least 8 characters"
5. Create a Google-only user (via `/auth/google`) → get token
6. `POST /auth/link-google` with a valid Google token → 200 success
7. Attempt same Google token from a different user account → 409 conflict
8. `POST /auth/login` with Google-only account email → 401 with updated message