### PR TITLE
feat: food database search (Open Food Facts) + nutrition label OCR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { settingsRouter } from './routes/settings';
 import { goalsRouter } from './routes/goals';
 import digestRouter from './routes/digest';
 import bodyStatsRouter from './routes/bodyStats';
+import nutritionRouter from './routes/nutrition';
 import { authenticate } from './middleware/auth';
 
 dotenv.config();
@@ -58,6 +59,7 @@ app.use('/settings', authenticate, settingsRouter);
 app.use('/goals', goalsRouter);
 app.use('/digest', authenticate, digestRouter);
 app.use('/body-stats', authenticate, bodyStatsRouter);
+app.use('/nutrition', authenticate, nutritionRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/models/Nutrition.ts
+++ b/src/models/Nutrition.ts
@@ -1,0 +1,118 @@
+import mongoose, { Document, Schema, Types } from 'mongoose';
+
+// ─── Food item within a meal ───────────────────────────────────────────────
+
+export interface IFoodItem {
+  name: string;
+  quantity: number;
+  unit: string;
+  nutrients: Map<string, number>;
+}
+
+const FoodItemSchema = new Schema<IFoodItem>(
+  {
+    name: { type: String, required: true, trim: true },
+    quantity: { type: Number, required: true },
+    unit: { type: String, required: true, trim: true },
+    nutrients: {
+      type: Map,
+      of: Number,
+      default: {},
+    },
+  },
+  { _id: false }
+);
+
+// ─── MealEntry model ───────────────────────────────────────────────────────
+
+export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack';
+
+export interface IMealEntry extends Document {
+  userId: Types.ObjectId;
+  date: string;
+  mealType: MealType;
+  foods: IFoodItem[];
+  rawText?: string;
+  createdAt: Date;
+}
+
+const MealEntrySchema = new Schema<IMealEntry>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    date: {
+      type: String,
+      required: true,
+      match: /^\d{4}-\d{2}-\d{2}$/,
+      index: true,
+    },
+    mealType: {
+      type: String,
+      enum: ['breakfast', 'lunch', 'dinner', 'snack'],
+      required: true,
+    },
+    foods: {
+      type: [FoodItemSchema],
+      default: [],
+    },
+    rawText: {
+      type: String,
+      trim: true,
+    },
+    createdAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { timestamps: false }
+);
+
+MealEntrySchema.index({ userId: 1, date: 1 });
+
+export const MealEntry = mongoose.model<IMealEntry>('MealEntry', MealEntrySchema);
+
+// ─── UserNutritionCategory model ───────────────────────────────────────────
+
+export type NutritionCategory =
+  | 'gym'
+  | 'weight-loss'
+  | 'diabetes'
+  | 'kidney'
+  | 'pregnancy'
+  | 'custom';
+
+export interface IUserNutritionCategory extends Document {
+  userId: Types.ObjectId;
+  category: NutritionCategory;
+  updatedAt: Date;
+}
+
+const UserNutritionCategorySchema = new Schema<IUserNutritionCategory>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      unique: true,
+    },
+    category: {
+      type: String,
+      enum: ['gym', 'weight-loss', 'diabetes', 'kidney', 'pregnancy', 'custom'],
+      default: 'gym',
+    },
+    updatedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  { timestamps: false }
+);
+
+export const UserNutritionCategory = mongoose.model<IUserNutritionCategory>(
+  'UserNutritionCategory',
+  UserNutritionCategorySchema
+);

--- a/src/routes/nutrition.ts
+++ b/src/routes/nutrition.ts
@@ -3,6 +3,7 @@ import { Types } from 'mongoose';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { AuthRequest } from '../middleware/auth';
 import { MealEntry, UserNutritionCategory, NutritionCategory } from '../models/Nutrition';
+import { CabinetItem } from '../models/CabinetItem';
 import { MODELS } from '../config/models';
 import { CATEGORY_TARGETS } from '../utils/nutritionTargets';
 
@@ -174,6 +175,177 @@ router.put('/category', async (req: AuthRequest, res: Response): Promise<void> =
   } catch (err) {
     console.error('[PUT /nutrition/category]', err);
     res.status(500).json({ success: false, data: null, error: 'Failed to update nutrition category' });
+  }
+});
+
+// ─── Supplement matching heuristic ───────────────────────────────────────
+// Maps nutrient names to keyword sets that identify matching supplements.
+
+const NUTRIENT_KEYWORDS: Record<string, string[]> = {
+  protein: ['protein', 'whey', 'casein'],
+  vitamin_d: ['vitamin d', 'vit d', 'd3'],
+  fat: ['omega', 'fish oil', 'epa', 'dha'],
+  iron: ['iron', 'ferrous'],
+  calcium: ['calcium'],
+  magnesium: ['magnesium', 'mag'],
+  zinc: ['zinc'],
+  folate: ['folate', 'folic', 'b9'],
+  fiber: ['fiber', 'fibre', 'psyllium'],
+};
+
+function supplementFillsGap(supplementName: string, nutrient: string): boolean {
+  const keywords = NUTRIENT_KEYWORDS[nutrient];
+  if (!keywords) return false;
+  const lowerName = supplementName.toLowerCase();
+  return keywords.some((kw) => lowerName.includes(kw));
+}
+
+// Cantonese nutrient display names
+const NUTRIENT_DISPLAY: Record<string, string> = {
+  protein: '蛋白質',
+  calories: '卡路里',
+  carbs: '碳水化合物',
+  fat: '脂肪',
+  sugar: '糖分',
+  fiber: '膳食纖維',
+  sodium: '鈉',
+  potassium: '鉀',
+  phosphorus: '磷',
+  folate: '葉酸',
+  iron: '鐵質',
+  calcium: '鈣質',
+  magnesium: '鎂',
+  zinc: '鋅',
+  vitamin_d: '維他命D',
+};
+
+function nutrientDisplayName(nutrient: string): string {
+  return NUTRIENT_DISPLAY[nutrient] ?? nutrient;
+}
+
+// ─── GET /nutrition/recommendations — supplement gap recommendations ──────
+
+router.get('/recommendations', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId as string;
+    const { date } = req.query as { date?: string };
+    const targetDate = typeof date === 'string' && DATE_REGEX.test(date) ? date : todayString();
+
+    // Step 1: Aggregate daily nutrients from MealEntry
+    const entries = await MealEntry.find({ userId, date: targetDate }).lean();
+
+    const totals: Record<string, number> = {};
+    for (const entry of entries) {
+      for (const food of entry.foods) {
+        const nutrientsMap = food.nutrients as unknown as Map<string, number> | Record<string, number>;
+        const pairs: [string, number][] =
+          nutrientsMap instanceof Map
+            ? Array.from(nutrientsMap.entries())
+            : Object.entries(nutrientsMap as Record<string, number>);
+        for (const [key, value] of pairs) {
+          totals[key] = (totals[key] ?? 0) + value;
+        }
+      }
+    }
+
+    // Step 2: Load user nutrition category (default: gym)
+    const categoryDoc = await UserNutritionCategory.findOne({ userId }).lean();
+    const category: NutritionCategory = categoryDoc?.category ?? 'gym';
+
+    // Step 3: Load targets and identify gaps
+    const targets = CATEGORY_TARGETS[category];
+
+    interface NutrientGap {
+      nutrient: string;
+      target: number;
+      actual: number;
+      gap: number;
+      unit: string;
+      type: 'min' | 'max';
+    }
+
+    const gaps: NutrientGap[] = [];
+
+    for (const t of targets) {
+      const actual = Math.round((totals[t.nutrient] ?? 0) * 10) / 10;
+      if (t.type === 'min' && actual < t.dailyTarget) {
+        gaps.push({
+          nutrient: t.nutrient,
+          target: t.dailyTarget,
+          actual,
+          gap: Math.round((t.dailyTarget - actual) * 10) / 10,
+          unit: t.unit,
+          type: 'min',
+        });
+      } else if (t.type === 'max' && actual > t.dailyTarget) {
+        gaps.push({
+          nutrient: t.nutrient,
+          target: t.dailyTarget,
+          actual,
+          gap: Math.round((actual - t.dailyTarget) * 10) / 10,
+          unit: t.unit,
+          type: 'max',
+        });
+      }
+    }
+
+    // Step 4: Fetch user's supplement cabinet (active supplements only)
+    const cabinet = await CabinetItem.find({
+      userId,
+      active: true,
+      type: { $in: ['supplement', 'vitamin'] },
+    }).lean();
+
+    // Step 5: Match supplements to gaps and build recommendations
+    interface Recommendation {
+      supplement: { id: string; name: string; dosage: string };
+      reason: string;
+      fillsGap: string;
+    }
+
+    const recommendations: Recommendation[] = [];
+    const filledGaps = new Set<string>();
+
+    for (const gap of gaps) {
+      for (const item of cabinet) {
+        if (supplementFillsGap(item.name, gap.nutrient)) {
+          const displayName = nutrientDisplayName(gap.nutrient);
+          const reason =
+            gap.type === 'min'
+              ? `你今日${displayName}仲差 ${gap.gap}${gap.unit}，${item.name} 可以幫你補返`
+              : `你今日${displayName}已超標 ${gap.gap}${gap.unit}，留意${item.name}唔好再加`;
+
+          recommendations.push({
+            supplement: {
+              id: (item._id as Types.ObjectId).toString(),
+              name: item.name,
+              dosage: item.dosage ?? '',
+            },
+            reason,
+            fillsGap: gap.nutrient,
+          });
+
+          filledGaps.add(gap.nutrient);
+          break; // one supplement per gap
+        }
+      }
+    }
+
+    const allGapsFilled = gaps.length > 0 && gaps.every((g) => filledGaps.has(g.nutrient));
+
+    res.json({
+      success: true,
+      data: {
+        date: targetDate,
+        gaps,
+        recommendations,
+        allGapsFilled,
+      },
+      error: null,
+    });
+  } catch (err) {
+    console.error('[GET /nutrition/recommendations]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to get recommendations' });
   }
 });
 

--- a/src/routes/nutrition.ts
+++ b/src/routes/nutrition.ts
@@ -1,0 +1,335 @@
+import { Router, Response } from 'express';
+import { Types } from 'mongoose';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import { AuthRequest } from '../middleware/auth';
+import { MealEntry, UserNutritionCategory, NutritionCategory } from '../models/Nutrition';
+import { MODELS } from '../config/models';
+import { CATEGORY_TARGETS } from '../utils/nutritionTargets';
+
+const router = Router();
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function todayString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+const getGenAI = () => {
+  const apiKey = process.env.GOOGLE_GEMINI_API_KEY;
+  if (!apiKey) throw new Error('GOOGLE_GEMINI_API_KEY is not set');
+  return new GoogleGenerativeAI(apiKey);
+};
+
+// ─── POST /nutrition/parse — AI food parsing ──────────────────────────────
+
+router.post('/parse', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { text, category } = req.body as { text?: unknown; category?: unknown };
+
+    if (typeof text !== 'string' || text.trim().length === 0) {
+      res.status(400).json({ success: false, data: null, error: 'text is required' });
+      return;
+    }
+
+    const genAI = getGenAI();
+    const model = genAI.getGenerativeModel({ model: MODELS.CHAT });
+
+    const prompt = `You are a nutrition expert. Parse the following food description and return structured nutrition data.
+The input may be in English, Cantonese, or Traditional Chinese (Hong Kong context). Recognise HK local food names.
+
+Food description: "${text.trim()}"
+${typeof category === 'string' && category.trim().length > 0 ? `Nutrition category context: ${category.trim()}` : ''}
+
+Return a JSON array of food items. Each item must have:
+- name: food name (keep original language if Chinese/Cantonese)
+- quantity: numeric quantity (number)
+- unit: serving unit (e.g. 碟, 杯, 碗, 份, g, ml, piece)
+- nutrients: object with any relevant values from: calories (kcal), protein (g), carbs (g), fat (g), sugar (g), fiber (g), sodium (mg), potassium (mg), phosphorus (mg), folate (µg), iron (mg), calcium (mg)
+
+Use realistic estimates for HK portion sizes. Return ONLY a valid JSON array, no markdown, no explanation.
+Example: [{"name":"叉燒飯","quantity":1,"unit":"碟","nutrients":{"calories":650,"protein":28,"carbs":80,"fat":18}}]`;
+
+    const result = await model.generateContent(prompt);
+    const text2 = result.response.text().trim();
+
+    // Extract JSON array from response (same pattern as cabinet ai-lookup)
+    const jsonMatch = text2.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) {
+      res.status(500).json({ success: false, data: null, error: 'AI returned unexpected format' });
+      return;
+    }
+
+    const foods = JSON.parse(jsonMatch[0]) as unknown[];
+    if (!Array.isArray(foods)) {
+      res.status(500).json({ success: false, data: null, error: 'AI returned unexpected format' });
+      return;
+    }
+
+    res.json({ success: true, data: { foods }, error: null });
+  } catch (err) {
+    console.error('[POST /nutrition/parse]', err);
+    res.status(500).json({ success: false, data: null, error: 'AI food parsing failed' });
+  }
+});
+
+// ─── GET /nutrition/summary — daily nutrient totals ───────────────────────
+// Must be defined before GET /nutrition/:id to avoid route conflict
+
+router.get('/summary', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId as string;
+    const { date } = req.query as { date?: string };
+    const targetDate = typeof date === 'string' && DATE_REGEX.test(date) ? date : todayString();
+
+    const entries = await MealEntry.find({ userId, date: targetDate }).lean();
+
+    // Aggregate nutrients across all meal entries for the day
+    const totals: Record<string, number> = {};
+    for (const entry of entries) {
+      for (const food of entry.foods) {
+        const nutrientsMap = food.nutrients as unknown as Map<string, number> | Record<string, number>;
+        const pairs: [string, number][] =
+          nutrientsMap instanceof Map
+            ? Array.from(nutrientsMap.entries())
+            : Object.entries(nutrientsMap as Record<string, number>);
+        for (const [key, value] of pairs) {
+          totals[key] = (totals[key] ?? 0) + value;
+        }
+      }
+    }
+
+    // Load category for this user (default: gym)
+    const categoryDoc = await UserNutritionCategory.findOne({ userId }).lean();
+    const category: NutritionCategory = categoryDoc?.category ?? 'gym';
+    const targets = CATEGORY_TARGETS[category];
+
+    // Build response: only nutrients that have a target defined
+    const nutrients: Record<
+      string,
+      { actual: number; target: number; unit: string; type: 'min' | 'max' }
+    > = {};
+
+    for (const t of targets) {
+      nutrients[t.nutrient] = {
+        actual: Math.round((totals[t.nutrient] ?? 0) * 10) / 10,
+        target: t.dailyTarget,
+        unit: t.unit,
+        type: t.type,
+      };
+    }
+
+    res.json({ success: true, data: { date: targetDate, category, nutrients }, error: null });
+  } catch (err) {
+    console.error('[GET /nutrition/summary]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to get nutrition summary' });
+  }
+});
+
+// ─── GET /nutrition/category — get user's nutrition category ──────────────
+
+router.get('/category', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId as string;
+    const doc = await UserNutritionCategory.findOne({ userId }).lean();
+    const category: NutritionCategory = doc?.category ?? 'gym';
+    res.json({ success: true, data: { category }, error: null });
+  } catch (err) {
+    console.error('[GET /nutrition/category]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to get nutrition category' });
+  }
+});
+
+// ─── PUT /nutrition/category — set user's nutrition category ─────────────
+
+router.put('/category', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId as string;
+    const { category } = req.body as { category?: unknown };
+
+    const validCategories: NutritionCategory[] = [
+      'gym',
+      'weight-loss',
+      'diabetes',
+      'kidney',
+      'pregnancy',
+      'custom',
+    ];
+
+    if (typeof category !== 'string' || !validCategories.includes(category as NutritionCategory)) {
+      res.status(400).json({
+        success: false,
+        data: null,
+        error: `category must be one of: ${validCategories.join(', ')}`,
+      });
+      return;
+    }
+
+    const doc = await UserNutritionCategory.findOneAndUpdate(
+      { userId },
+      { userId, category: category as NutritionCategory, updatedAt: new Date() },
+      { upsert: true, new: true }
+    );
+
+    res.json({ success: true, data: { category: doc.category }, error: null });
+  } catch (err) {
+    console.error('[PUT /nutrition/category]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to update nutrition category' });
+  }
+});
+
+// ─── GET /nutrition — list meal entries for a date ────────────────────────
+
+router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId as string;
+    const { date } = req.query as { date?: string };
+    const targetDate = typeof date === 'string' && DATE_REGEX.test(date) ? date : todayString();
+
+    const entries = await MealEntry.find({ userId, date: targetDate }).sort({ createdAt: 1 }).lean();
+    res.json({ success: true, data: entries, error: null });
+  } catch (err) {
+    console.error('[GET /nutrition]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to get meal entries' });
+  }
+});
+
+// ─── POST /nutrition — create meal entry ─────────────────────────────────
+
+router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId as string;
+    const { date, mealType, foods, rawText } = req.body as {
+      date?: unknown;
+      mealType?: unknown;
+      foods?: unknown;
+      rawText?: unknown;
+    };
+
+    if (typeof date !== 'string' || !DATE_REGEX.test(date)) {
+      res.status(400).json({ success: false, data: null, error: 'date must be a valid YYYY-MM-DD string' });
+      return;
+    }
+
+    const validMealTypes = ['breakfast', 'lunch', 'dinner', 'snack'];
+    if (typeof mealType !== 'string' || !validMealTypes.includes(mealType)) {
+      res.status(400).json({
+        success: false,
+        data: null,
+        error: `mealType must be one of: ${validMealTypes.join(', ')}`,
+      });
+      return;
+    }
+
+    if (!Array.isArray(foods)) {
+      res.status(400).json({ success: false, data: null, error: 'foods must be an array' });
+      return;
+    }
+
+    const entryData: Record<string, unknown> = {
+      userId,
+      date,
+      mealType,
+      foods,
+    };
+
+    if (typeof rawText === 'string' && rawText.trim().length > 0) {
+      entryData.rawText = rawText.trim();
+    }
+
+    const entry = await MealEntry.create(entryData);
+    res.status(201).json({ success: true, data: entry, error: null });
+  } catch (err) {
+    console.error('[POST /nutrition]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to create meal entry' });
+  }
+});
+
+// ─── PUT /nutrition/:id — update meal entry ───────────────────────────────
+
+router.put('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId as string;
+    const id = req.params.id as string;
+
+    if (!Types.ObjectId.isValid(id)) {
+      res.status(400).json({ success: false, data: null, error: 'Invalid entry id' });
+      return;
+    }
+
+    const existing = await MealEntry.findById(id);
+    if (!existing) {
+      res.status(404).json({ success: false, data: null, error: 'Meal entry not found' });
+      return;
+    }
+
+    if (existing.userId.toString() !== userId) {
+      res.status(403).json({ success: false, data: null, error: 'Forbidden' });
+      return;
+    }
+
+    const { date, mealType, foods, rawText } = req.body as {
+      date?: unknown;
+      mealType?: unknown;
+      foods?: unknown;
+      rawText?: unknown;
+    };
+
+    const updates: Record<string, unknown> = {};
+
+    if (typeof date === 'string' && DATE_REGEX.test(date)) {
+      updates.date = date;
+    }
+
+    const validMealTypes = ['breakfast', 'lunch', 'dinner', 'snack'];
+    if (typeof mealType === 'string' && validMealTypes.includes(mealType)) {
+      updates.mealType = mealType;
+    }
+
+    if (Array.isArray(foods)) {
+      updates.foods = foods;
+    }
+
+    if (typeof rawText === 'string') {
+      updates.rawText = rawText.trim();
+    }
+
+    const updated = await MealEntry.findByIdAndUpdate(id, updates, { new: true });
+    res.json({ success: true, data: updated, error: null });
+  } catch (err) {
+    console.error('[PUT /nutrition/:id]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to update meal entry' });
+  }
+});
+
+// ─── DELETE /nutrition/:id — delete meal entry ────────────────────────────
+
+router.delete('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = req.userId as string;
+    const id = req.params.id as string;
+
+    if (!Types.ObjectId.isValid(id)) {
+      res.status(400).json({ success: false, data: null, error: 'Invalid entry id' });
+      return;
+    }
+
+    const existing = await MealEntry.findById(id);
+    if (!existing) {
+      res.status(404).json({ success: false, data: null, error: 'Meal entry not found' });
+      return;
+    }
+
+    if (existing.userId.toString() !== userId) {
+      res.status(403).json({ success: false, data: null, error: 'Forbidden' });
+      return;
+    }
+
+    await MealEntry.findByIdAndDelete(id);
+    res.json({ success: true, data: { success: true }, error: null });
+  } catch (err) {
+    console.error('[DELETE /nutrition/:id]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to delete meal entry' });
+  }
+});
+
+export default router;

--- a/src/routes/nutrition.ts
+++ b/src/routes/nutrition.ts
@@ -73,6 +73,206 @@ Example: [{"name":"叉燒飯","quantity":1,"unit":"碟","nutrients":{"calories":
   }
 });
 
+// ─── Open Food Facts types ────────────────────────────────────────────────
+
+interface OFFProduct {
+  code?: string;
+  product_name?: string;
+  brands?: string;
+  serving_size?: string;
+  image_url?: string;
+  nutriments?: Record<string, number>;
+}
+
+interface OFFResponse {
+  products?: OFFProduct[];
+}
+
+interface FoodProduct {
+  id: string;
+  name: string;
+  brand: string;
+  servingSize: string;
+  source: 'database';
+  calories: number | null;
+  protein: number | null;
+  carbs: number | null;
+  fat: number | null;
+  sugar: number | null;
+  fiber: number | null;
+  sodium: number | null;
+  imageUrl: string | null;
+}
+
+function roundOrNull(value: number | undefined): number | null {
+  if (value === undefined || value === null) return null;
+  return Math.round(value * 10) / 10;
+}
+
+function pickNutrient(
+  nutriments: Record<string, number> | undefined,
+  servingKey: string,
+  per100Key: string
+): number | null {
+  if (!nutriments) return null;
+  const serving = nutriments[servingKey];
+  if (serving !== undefined) return roundOrNull(serving);
+  const per100 = nutriments[per100Key];
+  if (per100 !== undefined) return roundOrNull(per100);
+  return null;
+}
+
+// ─── GET /nutrition/search — Open Food Facts product search ───────────────
+
+router.get('/search', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { q } = req.query as { q?: string };
+
+    if (typeof q !== 'string' || q.trim().length === 0) {
+      res.status(400).json({ success: false, data: null, error: 'q (search query) is required' });
+      return;
+    }
+
+    const OFF_URL =
+      `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(q.trim())}` +
+      `&search_simple=1&action=process&json=1&page_size=10` +
+      `&fields=product_name,brands,serving_size,nutriments,image_url`;
+
+    let offData: OFFResponse = {};
+
+    try {
+      const offRes = await fetch(OFF_URL, {
+        headers: { 'User-Agent': 'Recallth/1.0 (health@recallth.app)' },
+      });
+      if (offRes.ok) {
+        offData = (await offRes.json()) as OFFResponse;
+      }
+    } catch (fetchErr) {
+      console.warn('[GET /nutrition/search] OFF fetch failed:', fetchErr);
+    }
+
+    const rawProducts: OFFProduct[] = offData.products ?? [];
+
+    const products: FoodProduct[] = rawProducts
+      .filter((p) => typeof p.product_name === 'string' && p.product_name.trim().length > 0)
+      .map((p) => {
+        const nutriments = p.nutriments;
+        const sodiumSrv = nutriments?.['sodium_serving'];
+        let sodium: number | null = null;
+        if (sodiumSrv !== undefined) {
+          // OFF returns sodium in g; convert to mg
+          sodium = roundOrNull(sodiumSrv < 1 ? sodiumSrv * 1000 : sodiumSrv);
+        }
+
+        const brands = typeof p.brands === 'string' ? p.brands : '';
+        const firstBrand = brands.split(',')[0]?.trim() ?? '';
+
+        return {
+          id: p.code ?? '',
+          name: (p.product_name ?? '').trim(),
+          brand: firstBrand,
+          servingSize: typeof p.serving_size === 'string' ? p.serving_size : '',
+          source: 'database' as const,
+          calories: pickNutrient(nutriments, 'energy-kcal_serving', 'energy-kcal_100g'),
+          protein: pickNutrient(nutriments, 'proteins_serving', 'proteins_100g'),
+          carbs: pickNutrient(nutriments, 'carbohydrates_serving', 'carbohydrates_100g'),
+          fat: pickNutrient(nutriments, 'fat_serving', 'fat_100g'),
+          sugar: roundOrNull(nutriments?.['sugars_serving']),
+          fiber: roundOrNull(nutriments?.['fiber_serving']),
+          sodium,
+          imageUrl: typeof p.image_url === 'string' ? p.image_url : null,
+        };
+      });
+
+    res.json({ success: true, data: { products, source: 'openfoodfacts' }, error: null });
+  } catch (err) {
+    console.error('[GET /nutrition/search]', err);
+    res.status(500).json({ success: false, data: null, error: 'Food search failed' });
+  }
+});
+
+// ─── POST /nutrition/ocr — Gemini vision nutrition label extraction ────────
+
+interface ExtractedFood {
+  name: string | null;
+  brand: string | null;
+  servingSize: string | null;
+  calories: number | null;
+  protein: number | null;
+  carbs: number | null;
+  fat: number | null;
+  sugar: number | null;
+  fiber: number | null;
+  sodium: number | null;
+}
+
+router.post('/ocr', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { image, mimeType } = req.body as { image?: unknown; mimeType?: unknown };
+
+    if (typeof image !== 'string' || image.trim().length === 0) {
+      res.status(400).json({ success: false, data: null, error: 'image (base64 string) is required' });
+      return;
+    }
+
+    if (typeof mimeType !== 'string' || mimeType.trim().length === 0) {
+      res.status(400).json({ success: false, data: null, error: 'mimeType is required' });
+      return;
+    }
+
+    const genAI = getGenAI();
+    const model = genAI.getGenerativeModel({ model: MODELS.CHAT });
+
+    const prompt = `You are a nutrition label reader. Extract all nutrition information from this food packaging image.
+Return a JSON object with these fields (use null for any field not found on the label):
+{
+  "name": "product name if visible",
+  "brand": "brand name if visible",
+  "servingSize": "serving size text (e.g. '30g', '1 cup')",
+  "calories": number or null,
+  "protein": number or null,
+  "carbs": number or null,
+  "fat": number or null,
+  "sugar": number or null,
+  "fiber": number or null,
+  "sodium": number or null
+}
+All nutrient values should be per serving (not per 100g). Return ONLY valid JSON, no markdown.`;
+
+    const result = await model.generateContent([
+      {
+        inlineData: {
+          mimeType: mimeType.trim(),
+          data: image.trim(),
+        },
+      },
+      prompt,
+    ]);
+
+    const rawText = result.response.text().trim();
+
+    // Strip markdown code fences if present
+    const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      res.json({ success: false, data: null, error: 'Could not read nutrition label' });
+      return;
+    }
+
+    let food: ExtractedFood;
+    try {
+      food = JSON.parse(jsonMatch[0]) as ExtractedFood;
+    } catch {
+      res.json({ success: false, data: null, error: 'Could not read nutrition label' });
+      return;
+    }
+
+    res.json({ success: true, data: { food }, error: null });
+  } catch (err) {
+    console.error('[POST /nutrition/ocr]', err);
+    res.status(500).json({ success: false, data: null, error: 'OCR processing failed' });
+  }
+});
+
 // ─── GET /nutrition/summary — daily nutrient totals ───────────────────────
 // Must be defined before GET /nutrition/:id to avoid route conflict
 

--- a/src/utils/nutritionTargets.ts
+++ b/src/utils/nutritionTargets.ts
@@ -1,0 +1,48 @@
+import type { NutritionCategory } from '../models/Nutrition';
+
+export interface NutrientTarget {
+  nutrient: string;
+  unit: string;
+  dailyTarget: number;
+  type: 'min' | 'max';
+}
+
+export const CATEGORY_TARGETS: Record<NutritionCategory, NutrientTarget[]> = {
+  gym: [
+    { nutrient: 'calories', unit: 'kcal', dailyTarget: 2500, type: 'min' },
+    { nutrient: 'protein', unit: 'g', dailyTarget: 150, type: 'min' },
+    { nutrient: 'carbs', unit: 'g', dailyTarget: 300, type: 'min' },
+    { nutrient: 'fat', unit: 'g', dailyTarget: 80, type: 'min' },
+  ],
+  'weight-loss': [
+    { nutrient: 'calories', unit: 'kcal', dailyTarget: 1800, type: 'max' },
+    { nutrient: 'fat', unit: 'g', dailyTarget: 60, type: 'max' },
+    { nutrient: 'sugar', unit: 'g', dailyTarget: 50, type: 'max' },
+    { nutrient: 'fiber', unit: 'g', dailyTarget: 25, type: 'min' },
+  ],
+  diabetes: [
+    { nutrient: 'carbs', unit: 'g', dailyTarget: 130, type: 'max' },
+    { nutrient: 'sugar', unit: 'g', dailyTarget: 25, type: 'max' },
+    { nutrient: 'fiber', unit: 'g', dailyTarget: 25, type: 'min' },
+    { nutrient: 'calories', unit: 'kcal', dailyTarget: 2000, type: 'max' },
+  ],
+  kidney: [
+    { nutrient: 'sodium', unit: 'mg', dailyTarget: 1500, type: 'max' },
+    { nutrient: 'potassium', unit: 'mg', dailyTarget: 2000, type: 'max' },
+    { nutrient: 'phosphorus', unit: 'mg', dailyTarget: 800, type: 'max' },
+    { nutrient: 'protein', unit: 'g', dailyTarget: 60, type: 'max' },
+  ],
+  pregnancy: [
+    { nutrient: 'calories', unit: 'kcal', dailyTarget: 2200, type: 'min' },
+    { nutrient: 'protein', unit: 'g', dailyTarget: 71, type: 'min' },
+    { nutrient: 'folate', unit: 'µg', dailyTarget: 600, type: 'min' },
+    { nutrient: 'iron', unit: 'mg', dailyTarget: 27, type: 'min' },
+    { nutrient: 'calcium', unit: 'mg', dailyTarget: 1000, type: 'min' },
+  ],
+  custom: [
+    { nutrient: 'calories', unit: 'kcal', dailyTarget: 2000, type: 'min' },
+    { nutrient: 'protein', unit: 'g', dailyTarget: 50, type: 'min' },
+    { nutrient: 'carbs', unit: 'g', dailyTarget: 250, type: 'min' },
+    { nutrient: 'fat', unit: 'g', dailyTarget: 65, type: 'min' },
+  ],
+};


### PR DESCRIPTION
## What
Two new endpoints added to `src/routes/nutrition.ts`:

**`GET /nutrition/search?q=<query>`**
- Proxies Open Food Facts API (no external package — uses native `fetch`)
- Normalises each product to a typed `FoodProduct` interface with per-serving calories, protein, carbs, fat, sugar, fiber, sodium
- Filters products with no name; silently returns empty array on OFF failure (frontend handles AI fallback)
- Sodium converted g→mg when value <1

**`POST /nutrition/ocr`**
- Accepts `{ image: string (base64), mimeType: string }`
- Passes image inline to Gemini vision (`gemini-2.5-flash-lite`) with structured prompt
- Returns `ExtractedFood` object with per-serving nutrient values
- Returns `{ success: false, error: 'Could not read nutrition label' }` on parse failure (not 500)

Both endpoints are behind existing auth middleware (same router).

## Why
Closes wkliwk/recallth#91

## Acceptance Criteria
- [x] `GET /nutrition/search?q=chicken+rice` returns `{ success: true, data: { products: FoodProduct[], source: 'openfoodfacts' }, error: null }`
- [x] Products missing `product_name` are filtered out
- [x] OFF failure → empty products array, no error to client
- [x] All nutrient values rounded to 1 decimal place
- [x] `POST /nutrition/ocr` missing `image` or `mimeType` → 400
- [x] Gemini JSON parse failure → `{ success: false, data: null, error: 'Could not read nutrition label' }`
- [x] `tsc --noEmit` passes with 0 errors
- [x] No new npm packages added

## Test Plan
1. Auth: obtain JWT via `POST /auth/login`
2. Search: `GET /nutrition/search?q=banana` with `Authorization: Bearer <token>` — expect product list from Open Food Facts
3. Search empty: `GET /nutrition/search?q=xyzzznotarealproduct` — expect `{ products: [] }`
4. OCR: `POST /nutrition/ocr` with a base64-encoded nutrition label image and `mimeType: "image/jpeg"` — expect extracted food object
5. OCR missing fields: `POST /nutrition/ocr` with empty body — expect 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)