### PR TITLE
feat: add GET /auth/me endpoint

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -107,6 +107,25 @@ router.post('/set-password', authenticate, async (req: AuthRequest, res: Respons
   res.json({ success: true, data: null, error: null });
 });
 
+// GET /auth/me
+router.get('/me', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const user = await User.findById(req.userId);
+  if (!user) {
+    res.status(404).json({ success: false, data: null, error: 'User not found' });
+    return;
+  }
+  res.json({
+    success: true,
+    data: {
+      userId: user._id,
+      email: user.email,
+      hasPassword: !!user.passwordHash,
+      googleLinked: !!user.googleId,
+    },
+    error: null,
+  });
+});
+
 // POST /auth/link-google
 router.post('/link-google', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
   const { googleToken } = req.body;


### PR DESCRIPTION
## What
Adds `GET /auth/me` — an authenticated endpoint that returns the current user's profile data needed by the `SecuritySection` frontend component.

## Why
Closes #136

The `SecuritySection` component calls `GET /auth/me` on mount to determine whether the user has a password set and whether Google is linked, so it can render the correct UI state. Without this endpoint the entire Security UI was broken.

## Acceptance Criteria
- [x] `GET /auth/me` requires a valid Bearer token (401 if missing/invalid)
- [x] Returns `userId`, `email`, `hasPassword`, `googleLinked` in the standard `{ success, data, error }` envelope
- [x] Returns 404 if the userId in the token no longer maps to a user document
- [x] `tsc --noEmit` passes with no errors

## Test Plan
```
# 1. Obtain a token via POST /auth/login
# 2. Call GET /auth/me with Authorization: Bearer <token>
# 3. Verify response shape:
{
  "success": true,
  "data": {
    "userId": "...",
    "email": "user@example.com",
    "hasPassword": true,
    "googleLinked": false
  },
  "error": null
}
# 4. Call without token → expect 401
# 5. Call with a valid token for a deleted user → expect 404
```