### PR TITLE
fix: exclude soft-deleted items from GET /cabinet

### DIFF
--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -202,7 +202,7 @@ router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
     res.status(404).json({ success: false, data: null, error: 'Family member not found' });
     return;
   }
-  const query: Record<string, unknown> = { userId: scopedUserId };
+  const query: Record<string, unknown> = { userId: scopedUserId, active: true };
 
   const validTypes: CabinetItemType[] = ['supplement', 'medication', 'vitamin'];
   if (req.query.type) {


### PR DESCRIPTION
## Summary

- Fixes `GET /cabinet` returning soft-deleted items (supplements with `active: false`) after deletion
- The delete flow (DELETE → soft-delete → 200 OK → redirect to `/cabinet`) appeared broken because the list refetch returned the deleted item

## Root Cause

`GET /cabinet` query defaulted to `{ userId }` with no `active` filter. Frontend calls `/cabinet` with no query params, so soft-deleted items were always included.

## Change

`src/routes/cabinet.ts` — one line:
```ts
// Before
const query: Record<string, unknown> = { userId: scopedUserId };
// After
const query: Record<string, unknown> = { userId: scopedUserId, active: true };
```

The existing `?active=false` override is preserved for any caller that needs to list archived items.

## Test plan

- [ ] Add a supplement → appears in list
- [ ] Delete supplement → disappears from list immediately
- [ ] Hard reload → supplement does not return

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)