### PR TITLE
feat: food images via Pexels + sessionTitle fixes (#178 #206)

### DIFF
--- a/src/models/FoodImageCache.ts
+++ b/src/models/FoodImageCache.ts
@@ -1,0 +1,15 @@
+import { Schema, model } from 'mongoose';
+
+interface IFoodImageCache {
+  key: string;       // normalised dish name (lowercase, trimmed)
+  imageUrl: string | null;
+  createdAt: Date;
+}
+
+const FoodImageCacheSchema = new Schema<IFoodImageCache>({
+  key: { type: String, required: true, unique: true, index: true },
+  imageUrl: { type: String, default: null },
+  createdAt: { type: Date, default: Date.now, expires: 60 * 60 * 24 * 30 }, // 30-day TTL
+});
+
+export const FoodImageCache = model<IFoodImageCache>('FoodImageCache', FoodImageCacheSchema);

--- a/src/models/Nutrition.ts
+++ b/src/models/Nutrition.ts
@@ -125,6 +125,7 @@ export interface IUserNutritionCustomConfig extends Document {
   userId: Types.ObjectId;
   nutrients: string[];
   goals: Map<string, number>;
+  aiSetupDone: boolean;
   updatedAt: Date;
 }
 
@@ -144,6 +145,10 @@ const UserNutritionCustomConfigSchema = new Schema<IUserNutritionCustomConfig>(
       type: Map,
       of: Number,
       default: {},
+    },
+    aiSetupDone: {
+      type: Boolean,
+      default: false,
     },
     updatedAt: {
       type: Date,

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -22,12 +22,13 @@ chatRouter.use(authenticate);
 // POST /chat — send message, get AI response
 chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
   const userId = req.userId as string;
-  const { message, conversationId, language, image, imageMimeType } = req.body as {
+  const { message, conversationId, language, image, imageMimeType, sessionTitle } = req.body as {
     message?: string;
     conversationId?: string;
     language?: string;
     image?: string;        // base64-encoded image data
     imageMimeType?: string; // e.g. 'image/jpeg', 'image/png'
+    sessionTitle?: string; // optional human-readable title for auto-sessions (e.g. Stack Builder)
   };
 
   if (!message || typeof message !== 'string' || message.trim().length === 0) {
@@ -66,13 +67,18 @@ chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
   const validImageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
   const hasImage = image && imageMimeType && validImageTypes.includes(imageMimeType);
 
+  const cleanSessionTitle = sessionTitle && typeof sessionTitle === 'string'
+    ? sessionTitle.slice(0, 80).trim()
+    : undefined;
+
   const result = await processChat(
     userId,
     message.trim(),
     conversationId,
     languageOverride,
     hasImage ? image : undefined,
-    hasImage ? imageMimeType : undefined
+    hasImage ? imageMimeType : undefined,
+    cleanSessionTitle
   );
 
   res.status(200).json({

--- a/src/routes/nutrition.ts
+++ b/src/routes/nutrition.ts
@@ -13,8 +13,39 @@ import { parseAiNutritionResponse } from '../utils/parseNutritionResponse';
 import { wholeFoodsLookup } from '../services/wholeFoodsRef';
 import { contributeToCommDB } from '../services/communityContribution';
 import { CommunityFoodItem } from '../models/CommunityFoodItem';
+import { FoodImageCache } from '../models/FoodImageCache';
 
 const router = Router();
+
+// ─── Pexels image lookup with MongoDB cache ───────────────────────────────
+async function fetchPexelsImage(dishName: string): Promise<string | null> {
+  const apiKey = process.env.PEXELS_API_KEY;
+  if (!apiKey) return null;
+
+  const key = dishName.toLowerCase().trim();
+
+  // 1. Check cache first
+  const cached = await FoodImageCache.findOne({ key }).lean();
+  if (cached !== null) return cached.imageUrl;
+
+  // 2. Call Pexels API
+  try {
+    const query = encodeURIComponent(dishName);
+    const res = await fetch(`https://api.pexels.com/v1/search?query=${query}&per_page=1&orientation=square`, {
+      headers: { Authorization: apiKey },
+    });
+    if (!res.ok) {
+      await FoodImageCache.updateOne({ key }, { key, imageUrl: null }, { upsert: true });
+      return null;
+    }
+    const data = await res.json() as { photos: Array<{ src: { medium: string } }> };
+    const imageUrl = data.photos?.[0]?.src?.medium ?? null;
+    await FoodImageCache.updateOne({ key }, { key, imageUrl }, { upsert: true });
+    return imageUrl;
+  } catch {
+    return null;
+  }
+}
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -352,21 +383,23 @@ router.get('/search', async (req: AuthRequest, res: Response): Promise<void> => 
       .lean();
 
     if (libraryItems.length > 0) {
-      const products: FoodProduct[] = libraryItems.map((item) => ({
-        id: (item._id as Types.ObjectId).toString(),
-        name: item.displayName,
-        brand: item.brand,
-        servingSize: item.servingSize,
-        source: 'library' as const,
-        calories: item.calories,
-        protein: item.protein,
-        carbs: item.carbs,
-        fat: item.fat,
-        sugar: item.sugar,
-        fiber: item.fiber,
-        sodium: item.sodium,
-        imageUrl: null,
-      }));
+      const products: FoodProduct[] = await Promise.all(
+        libraryItems.map(async (item) => ({
+          id: (item._id as Types.ObjectId).toString(),
+          name: item.displayName,
+          brand: item.brand,
+          servingSize: item.servingSize,
+          source: 'library' as const,
+          calories: item.calories,
+          protein: item.protein,
+          carbs: item.carbs,
+          fat: item.fat,
+          sugar: item.sugar,
+          fiber: item.fiber,
+          sodium: item.sodium,
+          imageUrl: await fetchPexelsImage(item.displayName),
+        }))
+      );
       res.json({ success: true, data: { products, source: 'library' }, error: null });
       return;
     }
@@ -396,7 +429,7 @@ router.get('/search', async (req: AuthRequest, res: Response): Promise<void> => 
           sugar: roundOrNull(p100.sugar),
           fiber: roundOrNull(p100.fiber),
           sodium: roundOrNull(p100.sodium),
-          imageUrl: null,
+          imageUrl: await fetchPexelsImage(communityItem.name),
         },
       ];
       res.json({
@@ -445,9 +478,9 @@ Example: [{"name":"雞胸肉","brand":"","servingSize":"100g","calories":165,"pr
       if (jsonMatch) {
         const items = JSON.parse(jsonMatch[0]) as Record<string, unknown>[];
         if (Array.isArray(items)) {
-          products = items
-            .filter((item) => typeof item.name === 'string' && item.name.trim().length > 0)
-            .map((item, idx) => ({
+          const filtered = items.filter((item) => typeof item.name === 'string' && item.name.trim().length > 0);
+          products = await Promise.all(
+            filtered.map(async (item, idx) => ({
               id: `ai-${idx}`,
               name: String(item.name ?? '').trim(),
               brand: String(item.brand ?? '').trim(),
@@ -460,8 +493,9 @@ Example: [{"name":"雞胸肉","brand":"","servingSize":"100g","calories":165,"pr
               sugar: typeof item.sugar === 'number' ? roundOrNull(item.sugar) : null,
               fiber: typeof item.fiber === 'number' ? roundOrNull(item.fiber) : null,
               sodium: typeof item.sodium === 'number' ? roundOrNull(item.sodium) : null,
-              imageUrl: null,
-            }));
+              imageUrl: await fetchPexelsImage(String(item.name ?? '').trim()),
+            }))
+          );
         }
       }
     } catch (aiErr) {

--- a/src/routes/nutrition.ts
+++ b/src/routes/nutrition.ts
@@ -575,13 +575,13 @@ router.get('/summary', async (req: AuthRequest, res: Response): Promise<void> =>
 
     // Attempt personalised targets if all body stats are present
     const body = profileDoc?.body;
-    const canPersonalise =
-      category !== 'custom' &&
+    const profileComplete =
       body?.weight != null &&
       body?.height != null &&
       body?.age != null &&
       (body?.sex === 'male' || body?.sex === 'female') &&
       body?.activityLevel != null;
+    const canPersonalise = category !== 'custom' && profileComplete;
 
     let targets = CATEGORY_TARGETS[category];
     let targetBasis: 'personalised' | 'default' = 'default';
@@ -611,7 +611,7 @@ router.get('/summary', async (req: AuthRequest, res: Response): Promise<void> =>
           type: existing?.type ?? 'min',
         };
       });
-      targetBasis = 'default';
+      targetBasis = profileComplete ? 'personalised' : 'default';
     } else if (canPersonalise) {
       const result = computePersonalisedTargets(
         category,
@@ -700,6 +700,101 @@ router.put('/category', async (req: AuthRequest, res: Response): Promise<void> =
   }
 });
 
+// ─── POST /nutrition/ai-goals — AI-recommended nutrient goals ────────────
+
+router.post('/ai-goals', async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const { goals, conditions, language } = req.body as {
+      goals?: unknown;
+      conditions?: unknown;
+      language?: unknown;
+    };
+
+    if (!Array.isArray(goals) || goals.length === 0) {
+      res.status(400).json({ success: false, data: null, error: 'goals is required' });
+      return;
+    }
+
+    const goalsStr = (goals as string[]).join(', ');
+    const conditionsStr =
+      Array.isArray(conditions) && conditions.length > 0
+        ? (conditions as string[]).join(', ')
+        : 'none';
+    const lang = typeof language === 'string' ? language : 'en';
+    const isChinese = lang === 'zh-HK' || lang === 'zh-TW';
+
+    const genAI = getGenAI();
+    const model = genAI.getGenerativeModel({ model: MODELS.CHAT });
+
+    const prompt = `You are a registered dietitian specialising in personalised nutrition.
+
+A user has provided their health goals and conditions. Recommend which nutrients they should track daily and set sensible daily targets.
+
+User health goals: ${goalsStr}
+User health conditions / dietary restrictions: ${conditionsStr}
+Response language: ${isChinese ? 'Traditional Chinese (Hong Kong Cantonese style)' : 'English'}
+
+Available nutrient keys (use ONLY these exact keys):
+calories (kcal), protein (g), carbs (g), fat (g), sugar (g), fiber (g), sodium (mg), folate (mcg), iron (mg)
+
+Return a JSON object with:
+- "nutrients": array of 3-6 nutrient keys most relevant for these goals/conditions
+- "goals": object mapping each selected key to a daily target number (assume average adult ~70kg, moderate activity unless conditions suggest otherwise)
+- "explanations": object mapping each selected key to a 1-sentence explanation in the response language (why this nutrient matters for their goals)
+
+Guidelines:
+- Weight loss: moderate calorie deficit ~1600-1800 kcal, high protein ~120-140g, lower carbs/sugar
+- Muscle building: maintenance or slight surplus ~2200-2500 kcal, high protein ~140-160g
+- Diabetes: track carbs <150g, sugar <25g, fiber >25g
+- Hypertension: track sodium <1500mg
+- Kidney disease: limit protein <50g, sodium <1500mg
+- Pregnancy: folate 600mcg, iron 27mg, protein ~71g
+- Heart health: fiber >25g, sodium <1500mg, fat <65g
+
+Return ONLY valid JSON, no markdown, no explanation.
+Example: {"nutrients":["calories","protein","carbs","fat"],"goals":{"calories":1700,"protein":130,"carbs":170,"fat":55},"explanations":{"calories":"Creating a moderate calorie deficit to support steady weight loss","protein":"High protein preserves muscle while in a calorie deficit","carbs":"Moderate carbs keep energy stable","fat":"Balanced fat supports hormones and satiety"}}`;
+
+    const result = await model.generateContent(prompt);
+    const rawText = result.response.text().trim();
+
+    let parsed: { nutrients: string[]; goals: Record<string, number>; explanations: Record<string, string> };
+    try {
+      const cleaned = rawText.replace(/^```json\s*/i, '').replace(/```\s*$/, '').trim();
+      parsed = JSON.parse(cleaned);
+    } catch {
+      res.status(500).json({ success: false, data: null, error: 'AI returned unexpected format' });
+      return;
+    }
+
+    const validNutrients = (parsed.nutrients ?? []).filter(
+      (k) => typeof k === 'string' && (VALID_NUTRIENT_KEYS as readonly string[]).includes(k)
+    );
+    if (validNutrients.length === 0) {
+      res.status(500).json({ success: false, data: null, error: 'AI returned no valid nutrients' });
+      return;
+    }
+
+    const validGoals: Record<string, number> = {};
+    for (const k of validNutrients) {
+      if (typeof parsed.goals?.[k] === 'number') validGoals[k] = parsed.goals[k];
+    }
+
+    const validExplanations: Record<string, string> = {};
+    for (const k of validNutrients) {
+      if (typeof parsed.explanations?.[k] === 'string') validExplanations[k] = parsed.explanations[k];
+    }
+
+    res.json({
+      success: true,
+      data: { nutrients: validNutrients, goals: validGoals, explanations: validExplanations },
+      error: null,
+    });
+  } catch (err) {
+    console.error('[POST /nutrition/ai-goals]', err);
+    res.status(500).json({ success: false, data: null, error: 'Failed to generate AI nutrient goals' });
+  }
+});
+
 // ─── GET /nutrition/custom-config — get user's custom nutrient config ─────
 
 router.get('/custom-config', async (req: AuthRequest, res: Response): Promise<void> => {
@@ -710,7 +805,7 @@ router.get('/custom-config', async (req: AuthRequest, res: Response): Promise<vo
     if (!doc) {
       res.json({
         success: true,
-        data: { nutrients: DEFAULT_CUSTOM_NUTRIENTS, goals: DEFAULT_CUSTOM_GOALS },
+        data: { nutrients: DEFAULT_CUSTOM_NUTRIENTS, goals: DEFAULT_CUSTOM_GOALS, aiSetupDone: false },
         error: null,
       });
       return;
@@ -722,7 +817,7 @@ router.get('/custom-config', async (req: AuthRequest, res: Response): Promise<vo
         ? Object.fromEntries(goalsMap.entries())
         : (goalsMap as Record<string, number>);
 
-    res.json({ success: true, data: { nutrients: doc.nutrients, goals }, error: null });
+    res.json({ success: true, data: { nutrients: doc.nutrients, goals, aiSetupDone: doc.aiSetupDone ?? false }, error: null });
   } catch (err) {
     console.error('[GET /nutrition/custom-config]', err);
     res.status(500).json({ success: false, data: null, error: 'Failed to get custom nutrient config' });
@@ -734,7 +829,7 @@ router.get('/custom-config', async (req: AuthRequest, res: Response): Promise<vo
 router.put('/custom-config', async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     const userId = req.userId as string;
-    const { nutrients, goals } = req.body as { nutrients?: unknown; goals?: unknown };
+    const { nutrients, goals, aiSetupDone } = req.body as { nutrients?: unknown; goals?: unknown; aiSetupDone?: unknown };
 
     // Validate nutrients
     if (!Array.isArray(nutrients) || nutrients.length === 0) {
@@ -795,9 +890,17 @@ router.put('/custom-config', async (req: AuthRequest, res: Response): Promise<vo
     const validatedNutrients = nutrients as string[];
     const validatedGoals = goalsObj as Record<string, number>;
 
+    const updateFields: Record<string, unknown> = {
+      userId,
+      nutrients: validatedNutrients,
+      goals: validatedGoals,
+      updatedAt: new Date(),
+    };
+    if (aiSetupDone === true) updateFields.aiSetupDone = true;
+
     const doc = await UserNutritionCustomConfig.findOneAndUpdate(
       { userId },
-      { userId, nutrients: validatedNutrients, goals: validatedGoals, updatedAt: new Date() },
+      updateFields,
       { upsert: true, new: true }
     );
 
@@ -807,7 +910,7 @@ router.put('/custom-config', async (req: AuthRequest, res: Response): Promise<vo
         ? Object.fromEntries(savedGoalsMap.entries())
         : (savedGoalsMap as Record<string, number>);
 
-    res.json({ success: true, data: { nutrients: doc.nutrients, goals: savedGoals }, error: null });
+    res.json({ success: true, data: { nutrients: doc.nutrients, goals: savedGoals, aiSetupDone: doc.aiSetupDone ?? false }, error: null });
   } catch (err) {
     console.error('[PUT /nutrition/custom-config]', err);
     res.status(500).json({ success: false, data: null, error: 'Failed to update custom nutrient config' });

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -562,7 +562,8 @@ export async function processChat(
   conversationId?: string,
   languageOverride?: DetectedLanguage,
   imageBase64?: string,
-  imageMimeType?: string
+  imageMimeType?: string,
+  sessionTitle?: string
 ): Promise<ChatResult> {
   const userObjectId = new Types.ObjectId(userId);
 
@@ -598,7 +599,7 @@ export async function processChat(
   } else {
     conversation = await Conversation.create({
       userId: userObjectId,
-      title: generateTitle(userMessage),
+      title: sessionTitle ?? generateTitle(userMessage),
       messages: [],
     });
   }
@@ -657,7 +658,8 @@ export async function processChat(
   await conversation.save();
 
   // Fire async title+summary generation after first exchange (non-blocking)
-  if (conversation.messages.length === 2 && !conversationId) {
+  // Skip if a sessionTitle was provided — it's already human-readable
+  if (conversation.messages.length === 2 && !conversationId && !sessionTitle) {
     void generateTitleAndSummary(String(conversation._id), userMessage);
   }
 


### PR DESCRIPTION
## Summary
- **#178** Accept `sessionTitle` in `POST /chat` so AI chat sessions show real titles in History (not system prompts)
- **#206** Pexels image lookup for food search results — MongoDB-cached, 30-day TTL, graceful fallback to null

## Changes
- `src/routes/chat.ts` — destructures `sessionTitle` from request body, passes to `processChat()`
- `src/services/chatService.ts` — uses `sessionTitle` if provided, skips AI title generation
- `src/models/FoodImageCache.ts` — new model with TTL index
- `src/routes/nutrition.ts` — `fetchPexelsImage()` helper; all three search paths now return `imageUrl`

## Test plan
- [ ] Search a food in FoodDB → card shows real Pexels photo
- [ ] Search same food again → served from cache (no Pexels API call)
- [ ] History page → AI chat sessions show real title, not system prompt text
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)