### PR TITLE
feat(goals): support {name,emoji,notes} objects in goals.primary (#230)

### DIFF
--- a/src/models/HealthProfile.ts
+++ b/src/models/HealthProfile.ts
@@ -40,8 +40,14 @@ export interface ILifestyle {
   smoking?: 'never' | 'former' | 'current';
 }
 
+export interface IGoalItem {
+  name: string;
+  emoji?: string;
+  notes?: string;
+}
+
 export interface IGoals {
-  primary?: string[];
+  primary?: Array<string | IGoalItem>;
 }
 
 export interface IBloodwork {
@@ -139,7 +145,7 @@ const LifestyleSchema = new Schema<ILifestyle>(
 
 const GoalsSchema = new Schema<IGoals>(
   {
-    primary: [{ type: String }],
+    primary: [{ type: mongoose.Schema.Types.Mixed }],
   },
   { _id: false }
 );


### PR DESCRIPTION
## Summary

Change `goals.primary` schema from `[String]` to `[Mixed]` to support goal objects with `name`, `emoji`, `notes` fields alongside legacy string entries.

Frontend PR: wkliwk/recallth#231
Issue: wkliwk/recallth#230

🤖 Generated with [Claude Code](https://claude.com/claude-code)