### PR TITLE
chore: auto-deploy to Railway on merge to main (#179)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+name: Deploy to Railway
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway
+        run: railway up --service recallth-backend --detach
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy.yml` — triggers `railway up` automatically whenever code is pushed/merged to `main`.

## ⚠️ One manual step required before this works

You must add `RAILWAY_TOKEN` to the GitHub repo secrets:

1. Go to [Railway dashboard](https://railway.com) → Project settings → Tokens
2. Create a new token named `github-actions-deploy`
3. Copy the token
4. Go to https://github.com/wkliwk/recallth-backend/settings/secrets/actions
5. Add secret: Name = `RAILWAY_TOKEN`, Value = (paste token)

Once the secret is added, every merge to main will auto-deploy.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)