### PR TITLE
debug: log language param in goals/insights

### DIFF
--- a/src/routes/goals.ts
+++ b/src/routes/goals.ts
@@ -178,6 +178,7 @@ goalsRouter.post('/insights', async (req: AuthRequest, res: Response): Promise<v
     const body = req.body as { goalName?: string; goalNotes?: string; language?: string };
     const { goalName, goalNotes, language } = body;
     const lang = (language === 'zh-HK' || language === 'zh-TW') ? language : 'en';
+    console.log(`[goals/insights] language=${JSON.stringify(language)} lang=${lang}`);
 
     if (!goalName || typeof goalName !== 'string' || goalName.trim().length === 0) {
       res.status(400).json({ error: 'goalName is required' });


### PR DESCRIPTION
Temporary diagnostic commit to confirm what `language` value the production backend is receiving.

Will check Railway logs after deploy to diagnose why zh-HK is returning English.

Closes #242