### PR TITLE
fix: resolve TypeScript error blocking Railway builds

### DIFF
--- a/src/services/wellnessScore.ts
+++ b/src/services/wellnessScore.ts
@@ -316,7 +316,9 @@ export async function computeWellnessScore(
   activeItems: ICabinetItem[],
   hasMajorInteraction: boolean
 ): Promise<WellnessScoreResult> {
-  const goals = profile?.goals?.primary ?? [];
+  const goals: string[] = (profile?.goals?.primary ?? []).map(g =>
+    typeof g === 'string' ? g : g.name
+  );
 
   const [profileBreakdown, cabinetBreakdown, goalAlignmentResult] = await Promise.all([
     Promise.resolve(scoreProfileCompleteness(profile)),


### PR DESCRIPTION
## What
`goals.primary` is typed as `Array<string | IGoalItem>` but `scoreGoalAlignment` expects `string[]`. This caused `tsc` to exit with code 2, failing the nixpacks build on every Railway deploy since the goals feature shipped.

## Fix
Map `goals.primary` entries to strings before passing to `scoreGoalAlignment`.

## Impact
This unblocks all pending backend changes from actually deploying — including the language fix for goals/insights (issue #242).