### PR TITLE
ci: add tsc check + remove --detach so build failures surface

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,16 +9,28 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
       - name: Install Railway CLI
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway
-        run: railway up --service recallth-backend --detach
+        run: railway up --service recallth-backend
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ app.use('/auth', authRouter);
 app.use('/auth', authGoogleRouter);
 app.use('/profile', profileRouter);
 app.use('/profile/auto-extracted', authenticate, extractionReviewRouter);
-app.get('/version', (_req, res) => res.json({ version: 'a9972f7', ts: Date.now() }));
+app.get('/version', (_req, res) => res.json({ version: process.env.RAILWAY_GIT_COMMIT_SHA ?? process.env.GIT_SHA ?? 'dev', ts: Date.now() }));
 app.use('/img', imageProxyRouter);  // image proxy — no auth (used as <img src>), at /img/image-proxy
 app.use('/cabinet', authenticate, cabinetRouter);
 app.use('/cabinet/interactions', authenticate, interactionsRouter);


### PR DESCRIPTION
## What
Railway builds were silently failing (tsc error → build fail → old container kept running). This was the root cause of issue #242 going undetected for hours.

## Changes
- **Type check step**: `npm ci && npx tsc --noEmit` runs before deploy. Any type error fails the job immediately — no deploy happens.
- **Remove `--detach`**: `railway up` now waits for the build to finish. If Railway build fails, GH Actions job turns red.
- **Real version SHA**: `/version` now returns `RAILWAY_GIT_COMMIT_SHA` so you can verify which commit is actually running on production with a single curl.

## How to verify
```bash
# After merge, hit production:
curl https://recallth-backend-production.up.railway.app/version
# → { "version": "<40-char-sha>", "ts": ... }
```

Closes #190