### PR TITLE
ci: inject GIT_SHA so /version returns real commit hash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway
-        run: railway up --service recallth-backend
+        run: |
+          railway variables set GIT_SHA=${{ github.sha }} --service recallth-backend
+          railway up --service recallth-backend
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
railway up doesn't set RAILWAY_GIT_COMMIT_SHA. Explicitly set GIT_SHA before each deploy via railway variables so /version is useful for verifying what's actually running.