### PR TITLE
feat: add_exercise_set action + fix AI hallucination (#263)

### DIFF
--- a/src/models/Conversation.ts
+++ b/src/models/Conversation.ts
@@ -3,7 +3,7 @@ import { Schema, model, Document, Types } from 'mongoose';
 export type MessageRole = 'user' | 'assistant';
 
 export interface IMessageAction {
-  type: 'save_profile' | 'add_cabinet';
+  type: 'save_profile' | 'add_cabinet' | 'add_exercise_set';
   label: string;
   data: Record<string, unknown>;
   applied?: boolean;
@@ -27,7 +27,7 @@ export interface IConversation extends Document {
 
 const ActionSchema = new Schema(
   {
-    type: { type: String, enum: ['save_profile', 'add_cabinet'], required: true },
+    type: { type: String, enum: ['save_profile', 'add_cabinet', 'add_exercise_set'], required: true },
     label: { type: String, required: true },
     data: { type: Schema.Types.Mixed, required: true },
     applied: { type: Boolean, default: false },

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -6,6 +6,7 @@ import { processChat, checkRateLimit } from '../services/chatService';
 import { Conversation } from '../models/Conversation';
 import { HealthProfile } from '../models/HealthProfile';
 import { CabinetItem } from '../models/CabinetItem';
+import { ExerciseSession } from '../models/ExerciseSession';
 import { MODELS } from '../config/models';
 
 const getGenAI = () => {
@@ -268,6 +269,52 @@ chatRouter.post('/apply-action', async (req: AuthRequest, res: Response): Promis
         );
       }
       res.json({ success: true, error: null, data: { applied: 'cabinet', action: 'created', itemId: String(item._id) } });
+    } else if (type === 'add_exercise_set') {
+      const sessionId = data.sessionId as string;
+      const exerciseName = data.exerciseName as string;
+      const sets = Number(data.sets);
+      const reps = Number(data.reps);
+      const weightKg = data.weightKg != null ? Number(data.weightKg) : undefined;
+
+      if (!sessionId || !exerciseName || isNaN(sets) || isNaN(reps)) {
+        res.status(400).json({ success: false, error: 'sessionId, exerciseName, sets, and reps are required', data: null });
+        return;
+      }
+      if (!Types.ObjectId.isValid(sessionId)) {
+        res.status(400).json({ success: false, error: 'Invalid sessionId', data: null });
+        return;
+      }
+
+      const session = await ExerciseSession.findById(sessionId);
+      if (!session) {
+        res.status(404).json({ success: false, error: 'Exercise session not found', data: null });
+        return;
+      }
+      if (session.userId.toString() !== userId) {
+        res.status(403).json({ success: false, error: 'Forbidden', data: null });
+        return;
+      }
+
+      const newEntry: { name: string; sets: number; reps: number; weightKg?: number } = {
+        name: exerciseName.trim(),
+        sets,
+        reps,
+        ...(weightKg != null && !isNaN(weightKg) ? { weightKg } : {}),
+      };
+      const updatedExercises = [...(session.exercises ?? []), newEntry];
+      const updated = await ExerciseSession.findByIdAndUpdate(
+        sessionId,
+        { $set: { exercises: updatedExercises } },
+        { new: true }
+      );
+
+      if (conversationId && messageIndex != null && actionIndex != null) {
+        await Conversation.updateOne(
+          { _id: new Types.ObjectId(conversationId), userId: userObjectId },
+          { $set: { [`messages.${messageIndex}.actions.${actionIndex}.applied`]: true } }
+        );
+      }
+      res.json({ success: true, error: null, data: { applied: 'exercise_set', sessionId, exerciseName, sets, reps, weightKg, updated: updated?.exercises } });
     } else {
       res.status(400).json({ success: false, error: `Unknown action type: ${type}`, data: null });
     }

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -203,8 +203,13 @@ DISCLAIMER (append to every response in the correct language on a new line):
 - 廣東話: "⚠️ 以上內容並非醫療建議。如有醫療需要，請諮詢專業醫護人員。"
 - 繁體中文: "⚠️ 以上內容僅供參考，並非醫療建議。請諮詢專業醫療人員。"
 
+CRITICAL DATA RULE (never violate this):
+You CANNOT directly write, save, update, or delete any data in the database. You have NO ability to perform database operations yourself. If the user asks you to add, record, or modify any data, you MUST:
+1. NOT claim you have done it (do not say "我已經幫你加埋" / "I've added it" / "已記錄" etc.)
+2. Instead, output an actions JSON block so the user can confirm the change with one tap.
+
 ACTION ITEMS (mandatory when applicable):
-If you detected any data from the user that could be saved (body stats, exercise habits, supplements, goals), output an actions JSON block BEFORE the disclaimer. Each action has a type, label (in the user's language), and data to save.
+If you detected any data from the user that could be saved (body stats, exercise habits, supplements, goals, exercise sets), output an actions JSON block BEFORE the disclaimer. Each action has a type, label (in the user's language), and data to save.
 
 Format — output EXACTLY this JSON (no markdown, no extra text around it):
 {"actions":[{"type":"save_profile","label":"...","data":{"field":"value"}},{"type":"add_cabinet","label":"...","data":{"name":"...","type":"supplement"}}]}
@@ -212,12 +217,14 @@ Format — output EXACTLY this JSON (no markdown, no extra text around it):
 Action types:
 - "save_profile": saves to health profile. data keys use dot notation: "body.height", "body.weight", "body.age", "body.sex", "exercise.frequency", "exercise.type", "exercise.goals", "goals.primary" (array), "diet.dietType", "sleep.quality", etc.
 - "add_cabinet": adds supplement to cabinet. data must have "name" and "type" ("supplement"|"medication"|"vitamin"), optionally "dosage", "frequency", "timing", "brand".
+- "add_exercise_set": adds an exercise entry to the current exercise session. Only use when a Session ID is present in the page context. data MUST have: "sessionId" (copy exactly from "Session ID:" in the page context), "exerciseName" (string), "sets" (number), "reps" (number). Optionally: "weightKg" (number). Example: if user says "幫我加多一個 Bench Press set 20下 80公斤", output {"type":"add_exercise_set","label":"加 Bench Press 1×20 @ 80kg","data":{"sessionId":"abc123","exerciseName":"Bench Press","sets":1,"reps":20,"weightKg":80}}
 
 Rules:
 - Only include actions for NEW data not already in the user's profile/cabinet above
 - Label should be short and descriptive in the user's language (e.g. "記錄身高體重 (173cm, 62kg)")
 - If no actions are applicable, omit the actions JSON block entirely
 - Do NOT include the "📋 快捷操作：" text section anymore — the actions JSON replaces it
+- NEVER claim to have written data — always use actions and let the user confirm
 
 FOLLOW-UP SUGGESTIONS (mandatory):
 After the disclaimer, on a new line, append EXACTLY this JSON block with 1–3 short follow-up questions the user might naturally ask next (under 10 words each, in the same language as your response):


### PR DESCRIPTION
## Summary
- Add CRITICAL DATA RULE to system prompt: AI cannot claim to write data — must use action buttons
- Add `add_exercise_set` action type to Conversation model and apply-action handler
- Handler appends a new exercise entry to the session's exercises array via PATCH /exercise/:id

## Changes
- `src/models/Conversation.ts` — added `'add_exercise_set'` to type union and enum
- `src/services/chatService.ts` — CRITICAL DATA RULE + `add_exercise_set` action type documented
- `src/routes/chat.ts` — imported ExerciseSession, added handler for `add_exercise_set`

Closes wkliwk/recallth#263 (partial — frontend PR separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)