### PR TITLE
feat(#271): ExerciseSet supports cardio type (durationMin, distanceKm)

### DIFF
--- a/src/models/ExerciseSession.ts
+++ b/src/models/ExerciseSession.ts
@@ -2,9 +2,14 @@ import { Schema, model, Document, Types } from 'mongoose';
 
 export interface ExerciseSet {
   name: string;
-  sets: number;
-  reps: number;
+  type?: 'strength' | 'cardio';
+  // strength fields
+  sets?: number;
+  reps?: number;
   weightKg?: number;
+  // cardio fields
+  durationMin?: number;
+  distanceKm?: number;
 }
 
 export interface IExerciseSession extends Document {
@@ -24,9 +29,12 @@ export interface IExerciseSession extends Document {
 const ExerciseSetSchema = new Schema<ExerciseSet>(
   {
     name: { type: String, required: true, trim: true },
-    sets: { type: Number, required: true },
-    reps: { type: Number, required: true },
+    type: { type: String, enum: ['strength', 'cardio'], default: 'strength' },
+    sets: { type: Number },
+    reps: { type: Number },
     weightKg: { type: Number },
+    durationMin: { type: Number },
+    distanceKm: { type: Number },
   },
   { _id: false },
 );


### PR DESCRIPTION
## Summary
- `ExerciseSet` interface adds `type?: 'strength' | 'cardio'`
- Adds optional `durationMin` and `distanceKm` fields
- Makes `sets` and `reps` optional (cardio rows don't have them)
- Mongoose schema updated with defaults

Closes wkliwk/recallth#271 (backend half)

🤖 Generated with [Claude Code](https://claude.com/claude-code)