### PR TITLE
feat(#282): add stretch/hiit types + rounds field to ExerciseSet

### DIFF
--- a/src/models/ExerciseSession.ts
+++ b/src/models/ExerciseSession.ts
@@ -2,14 +2,16 @@ import { Schema, model, Document, Types } from 'mongoose';
 
 export interface ExerciseSet {
   name: string;
-  type?: 'strength' | 'cardio';
+  type?: 'strength' | 'cardio' | 'stretch' | 'hiit';
   // strength fields
   sets?: number;
   reps?: number;
   weightKg?: number;
-  // cardio fields
+  // cardio / stretch fields
   durationMin?: number;
   distanceKm?: number;
+  // hiit fields
+  rounds?: number;
 }
 
 export interface IExerciseSession extends Document {
@@ -29,12 +31,13 @@ export interface IExerciseSession extends Document {
 const ExerciseSetSchema = new Schema<ExerciseSet>(
   {
     name: { type: String, required: true, trim: true },
-    type: { type: String, enum: ['strength', 'cardio'], default: 'strength' },
+    type: { type: String, enum: ['strength', 'cardio', 'stretch', 'hiit'], default: 'strength' },
     sets: { type: Number },
     reps: { type: Number },
     weightKg: { type: Number },
     durationMin: { type: Number },
     distanceKm: { type: Number },
+    rounds: { type: Number },
   },
   { _id: false },
 );


### PR DESCRIPTION
Extends ExerciseSet model to support 4 exercise types (strength, cardio, stretch, hiit) and adds rounds field for HIIT circuits.

Closes #282 (backend portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)