### PR TITLE
feat(#199): planned exercise sessions + plan_exercise AI action

### DIFF
--- a/src/models/Conversation.ts
+++ b/src/models/Conversation.ts
@@ -3,7 +3,7 @@ import { Schema, model, Document, Types } from 'mongoose';
 export type MessageRole = 'user' | 'assistant';
 
 export interface IMessageAction {
-  type: 'save_profile' | 'add_cabinet' | 'add_exercise_set';
+  type: 'save_profile' | 'add_cabinet' | 'add_exercise_set' | 'plan_exercise';
   label: string;
   data: Record<string, unknown>;
   applied?: boolean;
@@ -27,7 +27,7 @@ export interface IConversation extends Document {
 
 const ActionSchema = new Schema(
   {
-    type: { type: String, enum: ['save_profile', 'add_cabinet', 'add_exercise_set'], required: true },
+    type: { type: String, enum: ['save_profile', 'add_cabinet', 'add_exercise_set', 'plan_exercise'], required: true },
     label: { type: String, required: true },
     data: { type: Schema.Types.Mixed, required: true },
     applied: { type: Boolean, default: false },

--- a/src/models/ExerciseSession.ts
+++ b/src/models/ExerciseSession.ts
@@ -16,6 +16,7 @@ export interface ExerciseSet {
 
 export interface IExerciseSession extends Document {
   userId: Types.ObjectId;
+  status: 'planned' | 'completed';
   activityType: string;
   activityLabel?: string;
   date: string;
@@ -45,6 +46,7 @@ const ExerciseSetSchema = new Schema<ExerciseSet>(
 const ExerciseSessionSchema = new Schema<IExerciseSession>(
   {
     userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    status: { type: String, enum: ['planned', 'completed'], default: 'completed' },
     activityType: { type: String, required: true, trim: true },
     activityLabel: { type: String, trim: true },
     date: { type: String, required: true },

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -315,6 +315,33 @@ chatRouter.post('/apply-action', async (req: AuthRequest, res: Response): Promis
         );
       }
       res.json({ success: true, error: null, data: { applied: 'exercise_set', sessionId, exerciseName, sets, reps, weightKg, updated: updated?.exercises } });
+    } else if (type === 'plan_exercise') {
+      const activityType = data.activityType as string;
+      const date = data.date as string;
+      if (!activityType || !date) {
+        res.status(400).json({ success: false, error: 'activityType and date are required for plan_exercise', data: null });
+        return;
+      }
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+        res.status(400).json({ success: false, error: 'date must be YYYY-MM-DD', data: null });
+        return;
+      }
+      const session = await ExerciseSession.create({
+        userId: userObjectId,
+        status: 'planned',
+        activityType: activityType.trim(),
+        date,
+        durationMinutes: typeof data.durationMinutes === 'number' ? data.durationMinutes : 0,
+        intensity: typeof data.intensity === 'string' ? data.intensity : 'moderate',
+        notes: typeof data.notes === 'string' ? data.notes.trim() : undefined,
+      });
+      if (conversationId && messageIndex != null && actionIndex != null) {
+        await Conversation.updateOne(
+          { _id: new Types.ObjectId(conversationId), userId: userObjectId },
+          { $set: { [`messages.${messageIndex}.actions.${actionIndex}.applied`]: true } }
+        );
+      }
+      res.json({ success: true, error: null, data: { applied: 'plan_exercise', sessionId: String(session._id) } });
     } else {
       res.status(400).json({ success: false, error: `Unknown action type: ${type}`, data: null });
     }

--- a/src/routes/exercise.ts
+++ b/src/routes/exercise.ts
@@ -46,6 +46,7 @@ router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
   try {
     const userId = req.userId as string;
     const {
+      status,
       activityType,
       activityLabel,
       date,
@@ -55,6 +56,7 @@ router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
       exercises,
       notes,
     } = req.body as {
+      status?: unknown;
       activityType?: unknown;
       activityLabel?: unknown;
       date?: unknown;
@@ -64,6 +66,8 @@ router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
       exercises?: unknown;
       notes?: unknown;
     };
+
+    const isPlanned = status === 'planned';
 
     // Required field validation
     if (typeof activityType !== 'string' || activityType.trim().length === 0) {
@@ -76,26 +80,29 @@ router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
       return;
     }
 
-    if (typeof durationMinutes !== 'number' || durationMinutes <= 0) {
-      res.status(400).json({ success: false, message: 'durationMinutes must be a positive number' });
-      return;
-    }
-
-    const validIntensities = ['easy', 'moderate', 'hard'] as const;
-    if (typeof intensity !== 'string' || !validIntensities.includes(intensity as typeof validIntensities[number])) {
-      res.status(400).json({
-        success: false,
-        message: `intensity must be one of: ${validIntensities.join(', ')}`,
-      });
-      return;
+    // duration and intensity required for completed; optional for planned
+    if (!isPlanned) {
+      if (typeof durationMinutes !== 'number' || durationMinutes <= 0) {
+        res.status(400).json({ success: false, message: 'durationMinutes must be a positive number' });
+        return;
+      }
+      const validIntensities = ['easy', 'moderate', 'hard'] as const;
+      if (typeof intensity !== 'string' || !validIntensities.includes(intensity as typeof validIntensities[number])) {
+        res.status(400).json({
+          success: false,
+          message: `intensity must be one of: ${validIntensities.join(', ')}`,
+        });
+        return;
+      }
     }
 
     const sessionData: Record<string, unknown> = {
       userId,
+      status: isPlanned ? 'planned' : 'completed',
       activityType: activityType.trim(),
       date,
-      durationMinutes,
-      intensity,
+      durationMinutes: typeof durationMinutes === 'number' && durationMinutes > 0 ? durationMinutes : 0,
+      intensity: typeof intensity === 'string' ? intensity : 'moderate',
     };
 
     if (typeof activityLabel === 'string' && activityLabel.trim().length > 0) {

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -218,6 +218,7 @@ Action types:
 - "save_profile": saves to health profile. data keys use dot notation: "body.height", "body.weight", "body.age", "body.sex", "exercise.frequency", "exercise.type", "exercise.goals", "goals.primary" (array), "diet.dietType", "sleep.quality", etc.
 - "add_cabinet": adds supplement to cabinet. data must have "name" and "type" ("supplement"|"medication"|"vitamin"), optionally "dosage", "frequency", "timing", "brand".
 - "add_exercise_set": adds an exercise entry to the current exercise session. Only use when a Session ID is present in the page context. data MUST have: "sessionId" (copy exactly from "Session ID:" in the page context), "exerciseName" (string), "sets" (number), "reps" (number). Optionally: "weightKg" (number). Example: if user says "幫我加多一個 Bench Press set 20下 80公斤", output {"type":"add_exercise_set","label":"加 Bench Press 1×20 @ 80kg","data":{"sessionId":"abc123","exerciseName":"Bench Press","sets":1,"reps":20,"weightKg":80}}
+- "plan_exercise": saves a planned workout session for a future date. Use when the user asks for a workout plan or asks what they should do tomorrow / next session. data MUST have: "activityType" (one of: gym, running, swimming, basketball, badminton, cycling, yoga, hiking, other), "date" (YYYY-MM-DD, the suggested date), "durationMinutes" (number), "intensity" (easy|moderate|hard). Optionally: "notes" (string, brief description). Label should say "加入計劃：[activity] [duration]分鐘" in the user's language. Example: {"type":"plan_exercise","label":"加入計劃：跑步 30 分鐘","data":{"activityType":"running","date":"2026-04-23","durationMinutes":30,"intensity":"easy","notes":"輕鬆恢復跑"}}
 
 Rules:
 - Only include actions for NEW data not already in the user's profile/cabinet above
@@ -464,7 +465,7 @@ async function generateTitleAndSummary(
 
 // --- Parse actions JSON block from AI response ---
 interface ChatAction {
-  type: 'save_profile' | 'add_cabinet';
+  type: 'save_profile' | 'add_cabinet' | 'add_exercise_set' | 'plan_exercise';
   label: string;
   data: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- `ExerciseSession` model: new `status` field (`'planned'|'completed'`, default `'completed'`)
- `POST /exercise`: accepts `status: 'planned'`; duration/intensity optional for planned sessions
- `POST /chat/apply-action`: handles `plan_exercise` type → creates a planned `ExerciseSession`
- AI prompt: `plan_exercise` action type documented with schema + Cantonese example
- `IMessageAction` + `ChatAction` types updated to include `plan_exercise`

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)