### PR TITLE
fix: drop leading model entries from chat history (#209)

### DIFF
--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -647,6 +647,11 @@ export async function processChat(
       role: m.role === 'assistant' ? ('model' as const) : ('user' as const),
       parts: [{ text: m.content }] as [{ text: string }],
     }));
+    // Gemini requires history[0].role === 'user' — drop any leading model entries
+    // (can happen when slice(-20) boundary falls on an assistant message in long conversations)
+    while (existingHistory.length > 0 && existingHistory[0].role === 'model') {
+      existingHistory.shift();
+    }
   }
 
   // Call Gemini BEFORE creating/saving any conversation record


### PR DESCRIPTION
## Summary
- **#209** After `messages.slice(-20)`, drop any leading `model` entries before passing to `startChat({ history })`
- Gemini hard-requires `history[0].role === 'user'` — long conversations (>20 messages) where the slice boundary falls on an assistant message would throw 500 `First content should be with role 'user', got model`
- One-line defensive fix: `while (history[0]?.role === 'model') history.shift()`

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [ ] E2E: chat a conversation past 10 exchanges → no 500 on the 11th+

🤖 Generated with [Claude Code](https://claude.com/claude-code)