### PR TITLE
Expand HealthProfile: injuries, training goals, sports, focus areas

### DIFF
--- a/src/models/HealthProfile.ts
+++ b/src/models/HealthProfile.ts
@@ -50,6 +50,29 @@ export interface IGoals {
   primary?: Array<string | IGoalItem>;
 }
 
+export interface ITrainingGoal {
+  description: string;
+  targetMetric?: string;
+  targetValue?: number;
+  targetUnit?: string;
+  createdAt: Date;
+}
+
+export interface ISportsBackground {
+  sport: string;
+  experience?: string;
+  status: 'active' | 'learning' | 'past';
+}
+
+export interface IInjury {
+  name: string;
+  location?: string;
+  onsetDate?: string;
+  status: 'active' | 'recovering' | 'resolved';
+  notes?: string;
+  lastCheckedAt?: Date;
+}
+
 export interface IBloodwork {
   hba1c?: number;         // %
   totalCholesterol?: number; // mmol/L
@@ -85,6 +108,11 @@ export interface IHealthProfile extends Document {
   lifestyle: ILifestyle;
   goals: IGoals;
   bloodwork: IBloodwork;
+  trainingGoals: ITrainingGoal[];
+  focusAreas: string[];
+  sportsBackground: ISportsBackground[];
+  injuries: IInjury[];
+  freeformNotes: string;
   changeHistory: IChangeEntry[];
   createdAt: Date;
   updatedAt: Date;
@@ -167,6 +195,38 @@ const BloodworkSchema = new Schema<IBloodwork>(
   { _id: false }
 );
 
+const TrainingGoalSchema = new Schema<ITrainingGoal>(
+  {
+    description: { type: String, required: true },
+    targetMetric: { type: String },
+    targetValue: { type: Number },
+    targetUnit: { type: String },
+    createdAt: { type: Date, default: Date.now },
+  },
+  { _id: false }
+);
+
+const SportsBackgroundSchema = new Schema<ISportsBackground>(
+  {
+    sport: { type: String, required: true },
+    experience: { type: String },
+    status: { type: String, enum: ['active', 'learning', 'past'], default: 'active' },
+  },
+  { _id: false }
+);
+
+const InjurySchema = new Schema<IInjury>(
+  {
+    name: { type: String, required: true },
+    location: { type: String },
+    onsetDate: { type: String },
+    status: { type: String, enum: ['active', 'recovering', 'resolved'], default: 'active' },
+    notes: { type: String },
+    lastCheckedAt: { type: Date },
+  },
+  { _id: false }
+);
+
 const ChangeEntrySchema = new Schema<IChangeEntry>(
   {
     field: { type: String, required: true },
@@ -188,6 +248,11 @@ const HealthProfileSchema = new Schema<IHealthProfile>(
     lifestyle: { type: LifestyleSchema, default: () => ({}) },
     goals: { type: GoalsSchema, default: () => ({}) },
     bloodwork: { type: BloodworkSchema, default: () => ({}) },
+    trainingGoals: { type: [TrainingGoalSchema], default: [] },
+    focusAreas: { type: [String], default: [] },
+    sportsBackground: { type: [SportsBackgroundSchema], default: [] },
+    injuries: { type: [InjurySchema], default: [] },
+    freeformNotes: { type: String, default: '' },
     changeHistory: { type: [ChangeEntrySchema], default: [] },
   },
   { timestamps: true }

--- a/src/routes/profile.ts
+++ b/src/routes/profile.ts
@@ -106,6 +106,11 @@ router.get('/', authenticate, async (req: AuthRequest, res: Response): Promise<v
         lifestyle: {},
         goals: {},
         bloodwork: {},
+        trainingGoals: [],
+        focusAreas: [],
+        sportsBackground: [],
+        injuries: [],
+        freeformNotes: '',
         changeHistory: [],
       },
       error: null,
@@ -126,15 +131,19 @@ router.put('/', authenticate, async (req: AuthRequest, res: Response): Promise<v
     return;
   }
 
-  // Only accept recognised top-level category keys
-  const ALLOWED_CATEGORIES = ['body', 'diet', 'exercise', 'sleep', 'lifestyle', 'goals', 'bloodwork'] as const;
-  type Category = typeof ALLOWED_CATEGORIES[number];
+  // Only accept recognised top-level keys
+  // Object categories use dot-notation merging; direct fields are set as-is
+  const OBJECT_CATEGORIES = ['body', 'diet', 'exercise', 'sleep', 'lifestyle', 'goals', 'bloodwork'] as const;
+  const DIRECT_FIELDS = ['trainingGoals', 'focusAreas', 'sportsBackground', 'injuries', 'freeformNotes'] as const;
+  type ObjectCategory = typeof OBJECT_CATEGORIES[number];
+  type DirectField = typeof DIRECT_FIELDS[number];
+  const ALL_ALLOWED = [...OBJECT_CATEGORIES, ...DIRECT_FIELDS] as readonly string[];
 
-  const incoming = req.body as Partial<Record<Category, Record<string, unknown>>>;
+  const incoming = req.body as Record<string, unknown>;
 
-  // Validate: only known categories accepted
+  // Validate: only known keys accepted
   const unknownKeys = Object.keys(incoming).filter(
-    (k) => !ALLOWED_CATEGORIES.includes(k as Category)
+    (k) => !ALL_ALLOWED.includes(k)
   );
   if (unknownKeys.length > 0) {
     res.status(400).json({
@@ -153,9 +162,9 @@ router.put('/', authenticate, async (req: AuthRequest, res: Response): Promise<v
     profile = new HealthProfile({ userId });
   }
 
-  // Capture old flat values for change tracking
+  // Capture old flat values for change tracking (object categories only)
   const oldFlat = flattenObject(
-    ALLOWED_CATEGORIES.reduce<Record<string, unknown>>((acc, cat) => {
+    OBJECT_CATEGORIES.reduce<Record<string, unknown>>((acc, cat) => {
       const val = (profile as unknown as Record<string, unknown>)[cat];
       if (val && typeof val === 'object') {
         acc[cat] = (val as { toObject?: () => unknown }).toObject
@@ -171,9 +180,9 @@ router.put('/', authenticate, async (req: AuthRequest, res: Response): Promise<v
   // Apply partial updates using dot-notation $set to avoid overwriting sibling fields
   const setPayload: Record<string, unknown> = {};
 
-  for (const cat of ALLOWED_CATEGORIES) {
+  for (const cat of OBJECT_CATEGORIES) {
     if (!(cat in incoming)) continue;
-    const categoryData = incoming[cat];
+    const categoryData = incoming[cat] as Record<string, unknown>;
     if (typeof categoryData !== 'object' || categoryData === null || Array.isArray(categoryData)) {
       res.status(400).json({
         success: false,
@@ -185,6 +194,12 @@ router.put('/', authenticate, async (req: AuthRequest, res: Response): Promise<v
     for (const [field, value] of Object.entries(categoryData)) {
       setPayload[`${cat}.${field}`] = value;
     }
+  }
+
+  // Handle direct fields (arrays and strings) — set at top level, not dot-notation expanded
+  for (const field of DIRECT_FIELDS) {
+    if (!(field in incoming)) continue;
+    setPayload[field] = incoming[field];
   }
 
   // Build new flat snapshot for change detection

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -126,6 +126,11 @@ function buildSystemPrompt(
         lifestyle: profile.lifestyle,
         goals: profile.goals,
         bloodwork: profile.bloodwork,
+        trainingGoals: profile.trainingGoals,
+        focusAreas: profile.focusAreas,
+        sportsBackground: profile.sportsBackground,
+        injuries: profile.injuries,
+        freeformNotes: profile.freeformNotes,
       }
     : null;
 


### PR DESCRIPTION
## What
Add new fields to HealthProfile schema for richer athlete/fitness profiles: training goals, sports background, injuries, focus areas, and freeform notes. Update AI system prompt and PUT /profile endpoint to support these fields.

## Why
Closes #207

## Acceptance Criteria
- [x] New interfaces: ITrainingGoal, ISportsBackground, IInjury
- [x] New schema fields: trainingGoals, focusAreas, sportsBackground, injuries, freeformNotes
- [x] buildSystemPrompt() includes new fields in AI context
- [x] PUT /profile accepts and persists the new fields
- [x] GET /profile returns new fields in empty profile shell
- [x] tsc --noEmit passes with zero errors

## Test Plan
1. GET /profile for a new user — verify response includes empty arrays/string for new fields
2. PUT /profile with trainingGoals, injuries, sportsBackground, focusAreas, freeformNotes — verify they persist
3. Send a chat message — verify AI system prompt includes the new profile data