### PR TITLE
fix(#216): update deploy workflow from Railway to fly.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Railway
+name: Deploy to fly.io
 
 on:
   push:
@@ -27,12 +27,10 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
-      - name: Install Railway CLI
-        run: npm install -g @railway/cli
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Deploy to Railway
-        run: |
-          railway variables set GIT_SHA=${{ github.sha }} --service recallth-backend
-          railway up --service recallth-backend
+      - name: Deploy to fly.io
+        run: flyctl deploy --remote-only
         env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaced Railway CLI with `superfly/flyctl-actions` + `flyctl deploy --remote-only`
- Removed `RAILWAY_TOKEN` dependency
- Requires `FLY_API_TOKEN` GitHub secret (see below)

## Action required
Set `FLY_API_TOKEN` in repo settings → Secrets → Actions:
```bash
flyctl tokens create deploy -a recallth-backend
```
Copy the token → paste as `FLY_API_TOKEN` secret.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)