### PR TITLE
feat: isAdmin on User + adminAuth middleware + setAdmin script (#228)

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { User } from '../models/User';
 
 export interface AuthRequest extends Request {
   userId?: string;
@@ -29,5 +30,37 @@ export const authenticate = (
     next();
   } catch {
     res.status(401).json({ success: false, data: null, error: 'Invalid or expired token' });
+  }
+};
+
+export const adminAuth = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ success: false, error: 'Unauthorized' });
+    return;
+  }
+
+  const token = authHeader.split(' ')[1];
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    res.status(500).json({ success: false, error: 'Server misconfiguration' });
+    return;
+  }
+
+  try {
+    const payload = jwt.verify(token, secret) as { userId: string };
+    const user = await User.findById(payload.userId).lean();
+    if (!user?.isAdmin) {
+      res.status(403).json({ success: false, error: 'Forbidden' });
+      return;
+    }
+    req.userId = payload.userId;
+    next();
+  } catch {
+    res.status(401).json({ success: false, error: 'Invalid or expired token' });
   }
 };

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -5,6 +5,7 @@ export interface IUser extends Document {
   passwordHash?: string;
   googleId?: string;
   displayName?: string;
+  isAdmin: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -27,6 +28,10 @@ const UserSchema = new Schema<IUser>(
     },
     displayName: {
       type: String,
+    },
+    isAdmin: {
+      type: Boolean,
+      default: false,
     },
   },
   { timestamps: true }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -121,6 +121,7 @@ router.get('/me', authenticate, async (req: AuthRequest, res: Response): Promise
       email: user.email,
       hasPassword: !!user.passwordHash,
       googleLinked: !!user.googleId,
+      isAdmin: user.isAdmin ?? false,
     },
     error: null,
   });

--- a/src/scripts/setAdmin.ts
+++ b/src/scripts/setAdmin.ts
@@ -1,0 +1,47 @@
+/**
+ * One-time script to grant admin access to a user by email.
+ *
+ * Usage:
+ *   npx ts-node -r dotenv/config src/scripts/setAdmin.ts --email ricky@example.com
+ *   npx ts-node -r dotenv/config src/scripts/setAdmin.ts --email ricky@example.com --revoke
+ */
+
+import mongoose from 'mongoose';
+import { User } from '../models/User';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const emailArg = args.find(a => a.startsWith('--email='));
+  const email = emailArg?.split('=')[1];
+  const revoke = args.includes('--revoke');
+
+  if (!email) {
+    console.error('Usage: npx ts-node -r dotenv/config src/scripts/setAdmin.ts --email=user@example.com');
+    process.exit(1);
+  }
+
+  const mongoUri = process.env.MONGODB_URI;
+  if (!mongoUri) {
+    console.error('MONGODB_URI not set');
+    process.exit(1);
+  }
+
+  await mongoose.connect(mongoUri);
+
+  const user = await User.findOne({ email: email.toLowerCase() });
+  if (!user) {
+    console.error(`User not found: ${email}`);
+    process.exit(1);
+  }
+
+  user.isAdmin = !revoke;
+  await user.save();
+
+  console.log(`${revoke ? 'Revoked' : 'Granted'} admin for ${email} (userId: ${user._id})`);
+  await mongoose.disconnect();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- `isAdmin: Boolean` (default: false) added to User model and interface
- `adminAuth` middleware: verifies JWT + checks `user.isAdmin`, returns 403 if not admin
- `/auth/me` now includes `isAdmin` in response
- `src/scripts/setAdmin.ts` — grant/revoke admin by email: `npx ts-node -r dotenv/config src/scripts/setAdmin.ts --email=ricky@...`

Closes recallth-backend#228

🤖 Generated with [Claude Code](https://claude.com/claude-code)