### PR TITLE
perf: persist AI cache in MongoDB — interactions + evidence scores (#232)

### DIFF
--- a/src/models/AiCache.ts
+++ b/src/models/AiCache.ts
@@ -1,0 +1,42 @@
+import { Schema, model, Document } from 'mongoose';
+
+export interface IAiCache extends Document {
+  type: string;
+  key: string;
+  result: unknown;
+  createdAt: Date;
+}
+
+const AiCacheSchema = new Schema<IAiCache>(
+  {
+    type: { type: String, required: true },
+    key:  { type: String, required: true },
+    result: { type: Schema.Types.Mixed, required: true },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+// Compound unique index so upsert works cleanly
+AiCacheSchema.index({ type: 1, key: 1 }, { unique: true });
+
+// TTL: expire documents 24 hours after creation
+AiCacheSchema.index({ createdAt: 1 }, { expireAfterSeconds: 86400 });
+
+export const AiCache = model<IAiCache>('AiCache', AiCacheSchema);
+
+export async function getCached<T>(type: string, key: string): Promise<T | null> {
+  const doc = await AiCache.findOne({ type, key }).lean();
+  return doc ? (doc.result as T) : null;
+}
+
+export async function setCached<T>(type: string, key: string, result: T): Promise<void> {
+  await AiCache.findOneAndUpdate(
+    { type, key },
+    { $set: { result, createdAt: new Date() } },
+    { upsert: true }
+  );
+}
+
+export async function deleteCached(type: string, keyPattern: string): Promise<void> {
+  await AiCache.deleteMany({ type, key: new RegExp(keyPattern, 'i') });
+}

--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -11,6 +11,7 @@ import { HealthProfile } from '../models/HealthProfile';
 import { MODELS } from '../config/models';
 import { InsightCache } from '../models/InsightCache';
 import { buildAiUsage } from '../utils/aiUsage';
+import { getCached, setCached } from '../models/AiCache';
 
 async function resolveScopedUserId(
   ownerId: Types.ObjectId,
@@ -39,11 +40,11 @@ interface EvidenceScore {
   rationale: string;
 }
 
-const evidenceCache = new Map<string, { scores: EvidenceScore[]; expiresAt: number }>();
-const EVIDENCE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const EVIDENCE_CACHE_TYPE = 'evidence_scores';
 
-function bustEvidenceCache(userId: string) {
-  evidenceCache.delete(userId);
+async function bustEvidenceCache(userId: string) {
+  const { deleteCached } = await import('../models/AiCache');
+  await deleteCached(EVIDENCE_CACHE_TYPE, userId);
 }
 
 // ─── Redundancy cache (in-memory, 1-hour TTL per user) ───────────────────────
@@ -1521,10 +1522,10 @@ This is general health information, not personalised medical advice.`;
 router.get('/evidence-scores', async (req: AuthRequest, res: Response): Promise<void> => {
   const userId = req.userId as string;
 
-  // Return cached result if fresh
-  const cached = evidenceCache.get(userId);
-  if (cached && Date.now() < cached.expiresAt) {
-    res.json({ success: true, data: { scores: cached.scores }, error: null });
+  // Check MongoDB cache
+  const cached = await getCached<EvidenceScore[]>(EVIDENCE_CACHE_TYPE, userId);
+  if (cached) {
+    res.json({ success: true, data: { scores: cached }, error: null });
     return;
   }
 
@@ -1560,7 +1561,6 @@ If you don't recognise an item, assign D and say so in the rationale.`;
     let parsed: EvidenceScore[];
     try {
       parsed = JSON.parse(cleaned) as EvidenceScore[];
-      // Validate and normalise
       parsed = parsed
         .filter((s) => s.name && ['A', 'B', 'C', 'D'].includes(s.level))
         .map((s) => ({ name: s.name, level: s.level, rationale: s.rationale ?? '' }));
@@ -1569,7 +1569,7 @@ If you don't recognise an item, assign D and say so in the rationale.`;
       return;
     }
 
-    evidenceCache.set(userId, { scores: parsed, expiresAt: Date.now() + EVIDENCE_TTL_MS });
+    await setCached(EVIDENCE_CACHE_TYPE, userId, parsed);
     res.json({ success: true, data: { scores: parsed }, error: null });
   } catch (err) {
     console.error('[GET /cabinet/evidence-scores]', err);

--- a/src/services/interactionChecker.ts
+++ b/src/services/interactionChecker.ts
@@ -1,6 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { ICabinetItem } from '../models/CabinetItem';
 import { MODELS } from '../config/models';
+import { getCached, setCached, deleteCached } from '../models/AiCache';
 
 export interface Interaction {
   item1: string;
@@ -24,14 +25,7 @@ interface GeminiInteractionResponse {
 
 const VALID_SEVERITIES = new Set<string>(['minor', 'moderate', 'major']);
 
-// --- In-memory cache for interaction results ---
-interface CacheEntry {
-  result: Interaction[];
-  expiresAt: number;
-}
-
-const interactionCache = new Map<string, CacheEntry>();
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CACHE_TYPE = 'interactions';
 
 function getCacheKey(itemNames: string[]): string {
   return itemNames.sort().join('|').toLowerCase();
@@ -41,13 +35,8 @@ function getCacheKey(itemNames: string[]): string {
  * Invalidate cache entries that contain the given item name.
  * Call this whenever a cabinet item is added, updated, or removed.
  */
-export function invalidateInteractionCache(itemName: string): void {
-  const normalised = itemName.toLowerCase();
-  for (const key of interactionCache.keys()) {
-    if (key.split('|').includes(normalised)) {
-      interactionCache.delete(key);
-    }
-  }
+export async function invalidateInteractionCache(itemName: string): Promise<void> {
+  await deleteCached(CACHE_TYPE, itemName.toLowerCase());
 }
 
 function buildItemList(items: ICabinetItem[]): string {
@@ -136,13 +125,13 @@ async function runInteractionCheck(items: ICabinetItem[], prompt: string): Promi
     throw new Error('GOOGLE_GEMINI_API_KEY is not set');
   }
 
-  // Check cache before making API call
   const cacheKey = getCacheKey(items.map((i) => i.name));
-  const now = Date.now();
-  const cached = interactionCache.get(cacheKey);
-  if (cached && now < cached.expiresAt) {
+
+  // Check MongoDB cache
+  const cached = await getCached<Interaction[]>(CACHE_TYPE, cacheKey);
+  if (cached) {
     console.log(`[AI] model=${MODELS.INTERACTION} task=interaction cache_hit=true key="${cacheKey}"`);
-    return cached.result;
+    return cached;
   }
 
   const client = new GoogleGenerativeAI(apiKey);
@@ -158,8 +147,8 @@ async function runInteractionCheck(items: ICabinetItem[], prompt: string): Promi
 
   const result = parseGeminiResponse(text);
 
-  // Store in cache with TTL
-  interactionCache.set(cacheKey, { result, expiresAt: now + CACHE_TTL_MS });
+  // Persist to MongoDB (TTL handled by index)
+  await setCached(CACHE_TYPE, cacheKey, result);
 
   return result;
 }


### PR DESCRIPTION
## Summary
- New `AiCache` Mongoose model with compound unique index `{type, key}` + TTL index (24h expiry)
- `interactionChecker.ts`: replaced in-memory Map with MongoDB cache via `getCached/setCached`
- `cabinet.ts` `/evidence-scores`: replaced in-memory Map with MongoDB cache
- `bustEvidenceCache` + `invalidateInteractionCache` now call `deleteCached` against MongoDB

Closes #232