### PR TITLE
fix: cabinet images 404 — re-wrap stored proxy URLs with current host

### DIFF
--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -228,6 +228,13 @@ router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
 
   const items = await CabinetItem.find(query).sort({ createdAt: -1 }).lean();
 
+  // Re-wrap imageUrls through the current host's proxy.
+  // Stored URLs may be raw CDN URLs or old proxy URLs from a previous backend host
+  // (e.g. Railway). Extract the raw URL in either case and re-wrap with current host.
+  const proto = req.get('x-forwarded-proto') || req.protocol;
+  const host = req.get('host');
+  const currentBaseUrl = `${proto}://${host}`;
+
   const itemsWithComputed = items.map((item) => {
     const threshold = item.restockThresholdDays ?? 7;
     let daysSupplyRemaining: number | null = null;
@@ -236,7 +243,13 @@ router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
       daysSupplyRemaining = Math.floor(item.quantityRemaining / item.dailyDoseCount);
       lowSupplyWarning = daysSupplyRemaining <= threshold;
     }
-    return { ...item, daysSupplyRemaining, lowSupplyWarning };
+    let imageUrl = item.imageUrl as string | undefined;
+    if (imageUrl) {
+      const proxyMatch = imageUrl.match(/\/img\/image-proxy\?url=(.+)$/);
+      const rawImageUrl = proxyMatch ? decodeURIComponent(proxyMatch[1]) : imageUrl;
+      imageUrl = `${currentBaseUrl}/img/image-proxy?url=${encodeURIComponent(rawImageUrl)}`;
+    }
+    return { ...item, daysSupplyRemaining, lowSupplyWarning, imageUrl };
   });
 
   res.json({


### PR DESCRIPTION
## Summary
- `GET /cabinet` now re-wraps stored `imageUrl` values through the current request host's image proxy
- If a stored URL is already a proxy URL (from any previous backend host like Railway), the raw CDN URL is extracted first, then re-wrapped
- No DB migration needed — handled transparently at read time

## Root cause
`ai-lookup` built proxy URLs using the current request host when the item was searched. Users who saved cabinet items while the backend was on Railway got `https://recallth-backend-production.up.railway.app/img/image-proxy?url=...` stored in MongoDB. After migrating to fly.io, Railway is dead → 404.

## Test plan
- [ ] Navigate to `/cabinet` — images that previously 404'd should now load
- [ ] Add a new item via `ai-lookup` — image should work
- [ ] Network tab: proxy requests go to `recallth-backend.fly.dev`

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)