### PR TITLE
fix: #266 - Cabinet search only matches item name — extend to match brand and type fields

### DIFF
--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -226,6 +226,11 @@ router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
     }
   }
 
+  if (req.query.search) {
+    const regex = new RegExp(req.query.search as string, 'i');
+    query['$or'] = [{ name: regex }, { brand: regex }, { type: regex }];
+  }
+
   const items = await CabinetItem.find(query).sort({ createdAt: -1 }).lean();
 
   // Re-wrap imageUrls through the current host's proxy.


### PR DESCRIPTION
Closes #266

## Summary
- Added `?search=` query parameter support to `GET /cabinet`
- Search now matches case-insensitively across `name`, `brand`, and `type` fields via MongoDB `$or` regex query
- Existing `name`-only and `type`/`active` filter behaviour is unchanged

## Files changed
- `src/routes/cabinet.ts` — 5 lines added in the `GET /cabinet` handler

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2s7r57gxQDJcBMoxVPiEy)_