### PR TITLE
feat: #265 - reminder cron job with timezone-aware scheduling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "google-auth-library": "^10.6.2",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.4.1",
+        "node-cron": "^4.2.1",
         "pdfkit": "^0.18.0"
       },
       "devDependencies": {
@@ -27,6 +28,7 @@
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.6.0",
+        "@types/node-cron": "^3.0.11",
         "@types/supertest": "^7.2.0",
         "eslint": "^10.2.0",
         "jest": "^30.3.0",
@@ -1840,6 +1842,13 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/pdfkit": {
       "version": "0.17.5",
@@ -5957,6 +5966,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-domexception": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "google-auth-library": "^10.6.2",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.4.1",
+    "node-cron": "^4.2.1",
     "pdfkit": "^0.18.0"
   },
   "devDependencies": {
@@ -44,6 +45,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.6.0",
+    "@types/node-cron": "^3.0.11",
     "@types/supertest": "^7.2.0",
     "eslint": "^10.2.0",
     "jest": "^30.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import nutritionRouter from './routes/nutrition';
 import exerciseRouter from './routes/exercise';
 import adminRouter from './routes/admin';
 import { authenticate } from './middleware/auth';
+import { startReminderJob } from './services/reminderJob';
 
 dotenv.config();
 
@@ -72,6 +73,7 @@ app.use(errorHandler);
 
 const start = async () => {
   await connectDB();
+  startReminderJob();
   app.listen(Number(PORT), '0.0.0.0', () => {
     console.log(`Recallth API running on port ${PORT}`);
   });

--- a/src/services/reminderJob.ts
+++ b/src/services/reminderJob.ts
@@ -1,0 +1,45 @@
+import cron from 'node-cron';
+import { UserSettings } from '../models/UserSettings';
+
+// Dedup: tracks "userId:YYYY-MM-DD:HH:MM" keys to prevent double-fire within the same minute
+const firedKeys = new Set<string>();
+
+function getHHMM(tz: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: tz,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date());
+}
+
+function getDateStr(tz: string): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(new Date());
+}
+
+export function startReminderJob(): void {
+  cron.schedule('* * * * *', async () => {
+    try {
+      const allSettings = await UserSettings.find({ remindersEnabled: true }).lean();
+
+      for (const settings of allSettings) {
+        const tz = settings.timezone || 'UTC';
+        const currentHHMM = getHHMM(tz);
+
+        if (!settings.reminderTimes.includes(currentHHMM)) continue;
+
+        const userId = settings.userId.toString();
+        const dedupeKey = `${userId}:${getDateStr(tz)}:${currentHHMM}`;
+
+        if (firedKeys.has(dedupeKey)) continue;
+        firedKeys.add(dedupeKey);
+
+        console.log(`[ReminderJob] Reminder fired for user ${userId} at ${currentHHMM} (${tz})`);
+      }
+    } catch (err) {
+      console.error('[ReminderJob] Error in reminder cron:', err);
+    }
+  });
+
+  console.log('[ReminderJob] Reminder scheduler started (runs every minute)');
+}


### PR DESCRIPTION
Closes #265

## Summary
- Adds `node-cron` scheduler that runs every minute
- Queries all users with `remindersEnabled: true` and checks if any `reminderTimes` match the current `HH:MM` in their `timezone`
- Logs `[ReminderJob] Reminder fired for user {userId} at {HH:MM} ({tz})` on each match
- In-memory dedup set (`userId:YYYY-MM-DD:HH:MM`) prevents double-fire within the same minute
- Job starts automatically after DB connects in `src/index.ts`

## Files changed
- `src/services/reminderJob.ts` — new cron job service
- `src/index.ts` — import and start job after `connectDB()`
- `package.json` / `package-lock.json` — added `node-cron` + `@types/node-cron`

## Test plan
- [ ] Set `remindersEnabled: true`, `reminderTimes: ["HH:MM"]` (1 min from now), `timezone: "Asia/Hong_Kong"`
- [ ] Wait 1-2 minutes — confirm log line appears in server output
- [ ] `npx tsc --noEmit` passes with zero errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcerSuDAEZdWVVH8Fa9Scq)_