### PR TITLE
feat: #264 - Add GET /intake/status endpoint

### DIFF
--- a/src/routes/intake.ts
+++ b/src/routes/intake.ts
@@ -71,6 +71,18 @@ router.post('/log', authenticate, async (req: AuthRequest, res: Response) => {
   }
 });
 
+// GET /intake/status — check if user has logged today
+router.get('/status', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    const today = todayUTC();
+    const log = await IntakeLog.findOne({ userId: req.userId, date: today }).lean();
+    res.json({ logged: !!log, loggedAt: log ? log.createdAt : null });
+  } catch (error) {
+    console.error('Intake status GET error:', error);
+    res.status(500).json({ error: 'Failed to retrieve intake status' });
+  }
+});
+
 // GET /intake/streak — return streak data
 router.get('/streak', authenticate, async (req: AuthRequest, res: Response) => {
   try {


### PR DESCRIPTION
Closes #264

## Summary
- Adds `GET /intake/status` endpoint to `src/routes/intake.ts`
- Returns `{ logged: boolean, loggedAt: Date | null }` for the current UTC day
- Auth-protected via existing `authenticate` middleware
- Reuses existing `IntakeLog` model and `todayUTC()` helper — no new dependencies

## Test plan
- [ ] `GET /intake/status` before logging → `{ logged: false, loggedAt: null }`
- [ ] `POST /intake/log` to log today
- [ ] `GET /intake/status` after logging → `{ logged: true, loggedAt: "<timestamp>" }`
- [ ] Request without JWT → 401

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvkTJWVozeaa6xxtDmyfdF)_