### PR TITLE
fix: #261 - persist chat rate limit to MongoDB

### DIFF
--- a/src/models/RateLimit.ts
+++ b/src/models/RateLimit.ts
@@ -1,0 +1,21 @@
+import { Schema, model, Document } from 'mongoose';
+
+export interface IRateLimit extends Document {
+  userId: string;
+  windowStart: Date;
+  count: number;
+}
+
+const RateLimitSchema = new Schema<IRateLimit>(
+  {
+    userId: { type: String, required: true, index: true },
+    windowStart: { type: Date, required: true },
+    count: { type: Number, required: true, default: 0 },
+  },
+  { timestamps: false }
+);
+
+// TTL index — MongoDB auto-deletes documents 1 hour after windowStart
+RateLimitSchema.index({ windowStart: 1 }, { expireAfterSeconds: 3600 });
+
+export const RateLimit = model<IRateLimit>('RateLimit', RateLimitSchema);

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -48,7 +48,7 @@ chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
   }
 
   // Rate limiting
-  const rateCheck = checkRateLimit(userId);
+  const rateCheck = await checkRateLimit(userId);
   if (!rateCheck.allowed) {
     res.status(429).json({
       success: false,

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -8,6 +8,7 @@ import { DailyLog, IDailyLog } from '../models/DailyLog';
 import { SideEffect, ISideEffect } from '../models/SideEffect';
 import { ExerciseSession, IExerciseSession } from '../models/ExerciseSession';
 import { MealEntry, IMealEntry } from '../models/Nutrition';
+import { RateLimit } from '../models/RateLimit';
 import { detectLanguage, DetectedLanguage } from '../utils/language';
 import { MODELS } from '../config/models';
 import { buildAiUsage, AiUsage } from '../utils/aiUsage';
@@ -47,32 +48,30 @@ async function sendWithFallback(
   throw lastErr;
 }
 
-// --- Rate limiting ---
-interface RateLimitEntry {
-  count: number;
-  resetAt: number;
-}
-
-const rateLimitMap = new Map<string, RateLimitEntry>();
+// --- Rate limiting (MongoDB-backed, persists across restarts) ---
 const RATE_LIMIT_MAX = 30;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
 
-export function checkRateLimit(userId: string): { allowed: boolean; remaining: number; resetAt: number } {
-  const now = Date.now();
-  const entry = rateLimitMap.get(userId);
+export async function checkRateLimit(userId: string): Promise<{ allowed: boolean; remaining: number; resetAt: number }> {
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - RATE_LIMIT_WINDOW_MS);
 
-  if (!entry || now >= entry.resetAt) {
-    const newEntry: RateLimitEntry = { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS };
-    rateLimitMap.set(userId, newEntry);
-    return { allowed: true, remaining: RATE_LIMIT_MAX - 1, resetAt: newEntry.resetAt };
+  const entry = await RateLimit.findOne({ userId, windowStart: { $gt: windowStart } });
+
+  if (!entry) {
+    await RateLimit.create({ userId, windowStart: now, count: 1 });
+    return { allowed: true, remaining: RATE_LIMIT_MAX - 1, resetAt: now.getTime() + RATE_LIMIT_WINDOW_MS };
   }
 
+  const resetAt = entry.windowStart.getTime() + RATE_LIMIT_WINDOW_MS;
+
   if (entry.count >= RATE_LIMIT_MAX) {
-    return { allowed: false, remaining: 0, resetAt: entry.resetAt };
+    return { allowed: false, remaining: 0, resetAt };
   }
 
   entry.count += 1;
-  return { allowed: true, remaining: RATE_LIMIT_MAX - entry.count, resetAt: entry.resetAt };
+  await entry.save();
+  return { allowed: true, remaining: RATE_LIMIT_MAX - entry.count, resetAt };
 }
 
 // --- Language instruction builder ---


### PR DESCRIPTION
Closes #261

## Changes

- **New model** `src/models/RateLimit.ts` — `RateLimit` collection with `userId`, `windowStart`, `count` fields and a TTL index (`expireAfterSeconds: 3600`) so MongoDB auto-cleans expired windows.
- **`chatService.ts`** — replaced in-memory `Map` + `RateLimitEntry` interface with a MongoDB-backed `checkRateLimit` (now `async`). Same 30 msg / 1 hour window.
- **`chat.ts`** — `await checkRateLimit(userId)` (single-line change to match the new async signature).

## DoD
- [x] Rate limit state persisted to MongoDB (`RateLimit` collection)
- [x] Rate limit window unchanged (1 hour, 30 messages)
- [x] Rate limit persists across server restarts / re-deploys
- [x] Old in-memory Map removed from `chatService.ts`
- [x] `npx tsc --noEmit` passes (only pre-existing `@types/jest`/`@types/node` warnings, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAy6K2mfADTDUthvPqAGUe)_