### PR TITLE
feat: account deletion + forgot/reset password endpoints (#148 #149)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.4.1",
         "node-cron": "^4.2.1",
-        "pdfkit": "^0.18.0"
+        "pdfkit": "^0.18.0",
+        "resend": "^6.12.3"
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
@@ -1576,6 +1577,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.21",
@@ -3672,6 +3679,12 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6411,6 +6424,12 @@
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
       "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6571,6 +6590,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -6920,6 +6960,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7091,6 +7141,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/synckit": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.4.1",
     "node-cron": "^4.2.1",
-    "pdfkit": "^0.18.0"
+    "pdfkit": "^0.18.0",
+    "resend": "^6.12.3"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",

--- a/src/models/PasswordResetToken.ts
+++ b/src/models/PasswordResetToken.ts
@@ -1,0 +1,17 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IPasswordResetToken extends Document {
+  userId: Types.ObjectId;
+  token: string;
+  expiresAt: Date;
+}
+
+const PasswordResetTokenSchema = new Schema<IPasswordResetToken>({
+  userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  token: { type: String, required: true, unique: true },
+  expiresAt: { type: Date, required: true },
+});
+
+PasswordResetTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const PasswordResetToken = model<IPasswordResetToken>('PasswordResetToken', PasswordResetTokenSchema);

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -3,7 +3,10 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { OAuth2Client } from 'google-auth-library';
 import { User } from '../models/User';
+import { PasswordResetToken } from '../models/PasswordResetToken';
 import { authenticate, AuthRequest } from '../middleware/auth';
+import { Resend } from 'resend';
+import * as crypto from 'crypto';
 import { BloodworkEntry } from '../models/BloodworkEntry';
 import { BodyStatEntry } from '../models/BodyStatEntry';
 import { CabinetItem } from '../models/CabinetItem';
@@ -184,6 +187,71 @@ router.post('/link-google', authenticate, async (req: AuthRequest, res: Response
 
   user.googleId = googleId;
   await user.save();
+
+  res.json({ success: true, data: null, error: null });
+});
+
+// POST /auth/forgot-password — send a password reset email
+router.post('/forgot-password', async (req: Request, res: Response): Promise<void> => {
+  const { email } = req.body as { email?: string };
+  if (!email) {
+    res.status(400).json({ success: false, data: null, error: 'Email is required' });
+    return;
+  }
+
+  // Always return success to avoid email enumeration
+  const user = await User.findOne({ email: email.trim().toLowerCase() }).lean();
+  if (!user) {
+    res.json({ success: true, data: null, error: null });
+    return;
+  }
+
+  // Invalidate any existing tokens for this user
+  await PasswordResetToken.deleteMany({ userId: user._id });
+
+  const rawToken = crypto.randomBytes(32).toString('hex');
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+  await PasswordResetToken.create({ userId: user._id, token: rawToken, expiresAt });
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  if (resendApiKey) {
+    const resend = new Resend(resendApiKey);
+    const frontendUrl = process.env.FRONTEND_URL ?? 'https://recallth.app';
+    const resetUrl = `${frontendUrl}/reset-password?token=${rawToken}`;
+    await resend.emails.send({
+      from: 'Recallth <noreply@recallth.app>',
+      to: email.trim().toLowerCase(),
+      subject: 'Reset your Recallth password',
+      html: `<p>Click the link below to reset your password. This link expires in 1 hour.</p>
+             <p><a href="${resetUrl}">${resetUrl}</a></p>
+             <p>If you did not request a password reset, you can safely ignore this email.</p>`,
+    });
+  }
+
+  res.json({ success: true, data: null, error: null });
+});
+
+// POST /auth/reset-password — set a new password using a valid reset token
+router.post('/reset-password', async (req: Request, res: Response): Promise<void> => {
+  const { token, password } = req.body as { token?: string; password?: string };
+  if (!token || !password) {
+    res.status(400).json({ success: false, data: null, error: 'Token and password are required' });
+    return;
+  }
+  if (password.length < 8) {
+    res.status(400).json({ success: false, data: null, error: 'Password must be at least 8 characters' });
+    return;
+  }
+
+  const resetToken = await PasswordResetToken.findOne({ token, expiresAt: { $gt: new Date() } });
+  if (!resetToken) {
+    res.status(400).json({ success: false, data: null, error: 'Invalid or expired reset link' });
+    return;
+  }
+
+  const hashed = await bcrypt.hash(password, SALT_ROUNDS);
+  await User.findByIdAndUpdate(resetToken.userId, { password: hashed });
+  await PasswordResetToken.deleteOne({ _id: resetToken._id });
 
   res.json({ success: true, data: null, error: null });
 });

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -4,6 +4,22 @@ import jwt from 'jsonwebtoken';
 import { OAuth2Client } from 'google-auth-library';
 import { User } from '../models/User';
 import { authenticate, AuthRequest } from '../middleware/auth';
+import { BloodworkEntry } from '../models/BloodworkEntry';
+import { BodyStatEntry } from '../models/BodyStatEntry';
+import { CabinetItem } from '../models/CabinetItem';
+import { CabinetChangeLog } from '../models/CabinetChangeLog';
+import { Conversation } from '../models/Conversation';
+import { DailyLog } from '../models/DailyLog';
+import { DoseLog } from '../models/DoseLog';
+import { ExtractionReview } from '../models/ExtractionReview';
+import { GoalCheckIn } from '../models/GoalCheckIn';
+import { HealthProfile } from '../models/HealthProfile';
+import { InsightCache } from '../models/InsightCache';
+import { IntakeLog } from '../models/IntakeLog';
+import { MealEntry, UserNutritionCategory, UserNutritionCustomConfig } from '../models/Nutrition';
+import { SideEffect } from '../models/SideEffect';
+import { UserFoodItem } from '../models/UserFoodItem';
+import { UserSettings } from '../models/UserSettings';
 
 const router = Router();
 const SALT_ROUNDS = 12;
@@ -168,6 +184,40 @@ router.post('/link-google', authenticate, async (req: AuthRequest, res: Response
 
   user.googleId = googleId;
   await user.save();
+
+  res.json({ success: true, data: null, error: null });
+});
+
+// DELETE /auth/account — permanently delete the authenticated user and all their data
+router.delete('/account', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId;
+  if (!userId) {
+    res.status(401).json({ success: false, data: null, error: 'Unauthorized' });
+    return;
+  }
+
+  await Promise.all([
+    BloodworkEntry.deleteMany({ userId }),
+    BodyStatEntry.deleteMany({ userId }),
+    CabinetItem.deleteMany({ userId }),
+    CabinetChangeLog.deleteMany({ userId }),
+    Conversation.deleteMany({ userId }),
+    DailyLog.deleteMany({ userId }),
+    DoseLog.deleteMany({ userId }),
+    ExtractionReview.deleteMany({ userId }),
+    GoalCheckIn.deleteMany({ userId }),
+    HealthProfile.deleteOne({ userId }),
+    InsightCache.deleteMany({ userId }),
+    IntakeLog.deleteMany({ userId }),
+    MealEntry.deleteMany({ userId }),
+    UserNutritionCategory.deleteMany({ userId }),
+    UserNutritionCustomConfig.deleteMany({ userId }),
+    SideEffect.deleteMany({ userId }),
+    UserFoodItem.deleteMany({ userId }),
+    UserSettings.deleteOne({ userId }),
+  ]);
+
+  await User.deleteOne({ _id: userId });
 
   res.json({ success: true, data: null, error: null });
 });


### PR DESCRIPTION
## Summary

**#148 — DELETE /auth/account**
- Deletes the authenticated user's account and all associated data in parallel
- Collections deleted: BloodworkEntry, BodyStatEntry, CabinetItem, CabinetChangeLog, Conversation, DailyLog, DoseLog, ExtractionReview, GoalCheckIn, HealthProfile, InsightCache, IntakeLog, MealEntry, UserNutritionCategory, UserNutritionCustomConfig, SideEffect, UserFoodItem, UserSettings
- Finally deletes the User document itself

**#149 — POST /auth/forgot-password + POST /auth/reset-password**
- `PasswordResetToken` model: stores userId, token, expiresAt with MongoDB TTL index (auto-expires after 1 hour)
- `POST /auth/forgot-password`: looks up user by email, generates `crypto.randomBytes(32)` token, stores it, sends reset email via Resend. Returns success regardless of whether email exists (prevents enumeration).
- `POST /auth/reset-password`: validates token is unexpired, bcrypt-hashes new password, updates User, deletes used token
- Requires `RESEND_API_KEY` Fly secret for email delivery; endpoints function without it (no email sent)

## Test plan
- [ ] `DELETE /auth/account` with valid token → 200, user and all data deleted
- [ ] `POST /auth/forgot-password` with registered email → 200, token stored in DB
- [ ] `POST /auth/reset-password` with valid token + new password → 200, password updated
- [ ] `POST /auth/reset-password` with expired/invalid token → 400 error
- [ ] `npx tsc --noEmit` passes (excluding pre-existing reminderJob.ts node-cron error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)