### PR TITLE
fix: expand schedule timing keyword mapping (#253)

### DIFF
--- a/src/routes/cabinet.ts
+++ b/src/routes/cabinet.ts
@@ -1280,10 +1280,10 @@ router.get('/schedule', async (req: AuthRequest, res: Response): Promise<void> =
   type Slot = 'morning' | 'afternoon' | 'evening' | 'night' | 'anytime';
 
   const SLOT_KEYWORDS: Record<Slot, string[]> = {
-    morning: ['morning', 'am', 'wake up', 'breakfast', 'empty stomach'],
-    afternoon: ['afternoon', 'lunch', 'midday'],
-    evening: ['evening', 'dinner', 'pm', 'with dinner'],
-    night: ['night', 'bedtime', 'before bed', 'sleep'],
+    morning: ['morning', 'am', 'wake up', 'breakfast', 'with breakfast', 'empty stomach', 'post-workout', 'after workout', 'post workout'],
+    afternoon: ['afternoon', 'lunch', 'with lunch', 'midday', 'noon'],
+    evening: ['evening', 'dinner', 'pm', 'with dinner', 'supper', 'with supper'],
+    night: ['night', 'bedtime', 'before bed', 'sleep', 'nighttime'],
     anytime: [],
   };
 


### PR DESCRIPTION
## Summary
- Extended `SLOT_KEYWORDS` in `GET /cabinet/schedule` to handle common supplement timing strings that were previously falling through to `anytime`
- Added: `with breakfast` → morning, `post-workout` / `after workout` / `post workout` → morning, `with lunch` → afternoon, `noon` → afternoon, `supper` / `with supper` → evening, `nighttime` → night

## Test plan
- [ ] Supplement with timing "Post-workout" → appears in morning slot
- [ ] Supplement with timing "With breakfast" → appears in morning slot
- [ ] Supplement with timing "With lunch" → appears in afternoon slot
- [ ] Supplement with timing "Midday" → appears in afternoon slot
- [ ] Existing timings unchanged (Morning → morning, Evening → evening, Before bed → night)
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)