### PR TITLE
feat: body-stats/latest endpoint + chat history pagination (#252, #257)

### DIFF
--- a/src/routes/bodyStats.ts
+++ b/src/routes/bodyStats.ts
@@ -58,6 +58,39 @@ router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
   }
 });
 
+// GET /body-stats/latest — return most recent values for each stat
+router.get('/latest', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId;
+    // Fetch last 90 entries (enough history to find latest of each stat)
+    const entries = await BodyStatEntry.find({ userId })
+      .sort({ date: -1 })
+      .limit(90)
+      .lean();
+
+    type StatValue = { value: number; date: string } | null;
+    const result: {
+      weight: StatValue;
+      bodyFat: StatValue;
+      muscleMass: StatValue;
+      waist: StatValue;
+    } = { weight: null, bodyFat: null, muscleMass: null, waist: null };
+
+    for (const e of entries) {
+      if (result.weight === null && e.weight != null) result.weight = { value: e.weight, date: e.date };
+      if (result.bodyFat === null && e.bodyFat != null) result.bodyFat = { value: e.bodyFat, date: e.date };
+      if (result.muscleMass === null && e.muscleMass != null) result.muscleMass = { value: e.muscleMass, date: e.date };
+      if (result.waist === null && e.waist != null) result.waist = { value: e.waist, date: e.date };
+      if (result.weight && result.bodyFat && result.muscleMass && result.waist) break;
+    }
+
+    res.json({ success: true, data: result });
+  } catch (error) {
+    console.error('[GET /body-stats/latest]', error);
+    res.status(500).json({ success: false, error: 'Failed to retrieve latest body stats' });
+  }
+});
+
 // GET /body-stats — list entries, sorted by date desc
 router.get('/', authenticate, async (req: AuthRequest, res: Response) => {
   try {

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -96,27 +96,38 @@ chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
   });
 });
 
-// GET /chat/history — list conversations (paginated, 20/page)
+// GET /chat/history — list conversations, supports ?limit=N&offset=M or legacy ?page=N
 chatRouter.get('/history', async (req: AuthRequest, res: Response): Promise<void> => {
   const userId = req.userId as string;
-  const page = Math.max(1, parseInt(String(req.query.page ?? '1'), 10));
-  const limit = 20;
-  const skip = (page - 1) * limit;
+  const { limit: limitParam, offset: offsetParam, page: pageParam } = req.query as {
+    limit?: string; offset?: string; page?: string;
+  };
 
-  const conversations = await Conversation.aggregate([
-    { $match: { userId: new Types.ObjectId(userId), 'messages.0': { $exists: true } } },
-    { $sort: { createdAt: -1 } },
-    { $skip: skip },
-    { $limit: limit },
-    {
-      $project: {
-        _id: 1,
-        title: 1,
-        summary: 1,
-        createdAt: 1,
-        messageCount: { $size: '$messages' },
+  const limit = Math.min(100, Math.max(1, parseInt(limitParam ?? '20', 10) || 20));
+  const page = Math.max(1, parseInt(pageParam ?? '1', 10));
+  const skip = offsetParam != null
+    ? Math.max(0, parseInt(offsetParam, 10) || 0)
+    : (page - 1) * limit;
+
+  const matchStage = { userId: new Types.ObjectId(userId), 'messages.0': { $exists: true } };
+
+  const [conversations, total] = await Promise.all([
+    Conversation.aggregate([
+      { $match: matchStage },
+      { $sort: { createdAt: -1 } },
+      { $skip: skip },
+      { $limit: limit },
+      {
+        $project: {
+          _id: 1,
+          title: 1,
+          summary: 1,
+          createdAt: 1,
+          messageCount: { $size: '$messages' },
+        },
       },
-    },
+    ]),
+    Conversation.countDocuments(matchStage),
   ]);
 
   res.status(200).json({
@@ -124,8 +135,11 @@ chatRouter.get('/history', async (req: AuthRequest, res: Response): Promise<void
     error: null,
     data: {
       conversations,
-      page,
+      total,
+      hasMore: skip + conversations.length < total,
       limit,
+      offset: skip,
+      page,
     },
   });
 });


### PR DESCRIPTION
## Summary
- **#257**: `GET /body-stats/latest` — returns most recent value for each stat (weight, bodyFat, muscleMass, waist) as `{ value, date }` objects or `null`. Fetches last 90 entries and short-circuits once all 4 stats are found.
- **#252**: `GET /chat/history` now accepts `?limit=N&offset=M` (default 20, max 100). Response includes `total`, `hasMore`, `offset`. Legacy `?page=N` still works. Parallel `countDocuments` query powers `total`/`hasMore`.

## Test plan
- [ ] `GET /body-stats/latest` returns `{ weight: { value, date }, bodyFat: null, ... }` reflecting most recent logged values
- [ ] `GET /chat/history?limit=5&offset=0` returns 5 conversations, `hasMore: true` if more exist
- [ ] `GET /chat/history?limit=5&offset=5` returns next 5
- [ ] `GET /chat/history?page=2` (legacy) still works
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)