### PR TITLE
feat(chat): X-RateLimit-Remaining and X-RateLimit-Reset headers (#259)

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -49,12 +49,15 @@ chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
 
   // Rate limiting
   const rateCheck = await checkRateLimit(userId);
+  const resetAtISO = new Date(rateCheck.resetAt).toISOString();
   if (!rateCheck.allowed) {
+    res.set('X-RateLimit-Remaining', '0');
+    res.set('X-RateLimit-Reset', resetAtISO);
     res.status(429).json({
       success: false,
       error: 'Rate limit exceeded. Maximum 30 messages per hour.',
       data: {
-        resetAt: new Date(rateCheck.resetAt).toISOString(),
+        resetAt: resetAtISO,
         remaining: 0,
       },
     });
@@ -82,6 +85,8 @@ chatRouter.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
     cleanSessionTitle
   );
 
+  res.set('X-RateLimit-Remaining', String(rateCheck.remaining));
+  res.set('X-RateLimit-Reset', resetAtISO);
   res.status(200).json({
     success: true,
     error: null,


### PR DESCRIPTION
## Summary
Adds two response headers to `POST /chat`:
- `X-RateLimit-Remaining: N` — messages left in the current 1-hour window
- `X-RateLimit-Reset: <ISO>` — when the window resets

Both headers are set on successful (200) and rate-limited (429) responses. Values come from the existing `checkRateLimit()` call (no additional DB query).

## Test plan
- [ ] `POST /chat { "message": "hi" }` → response headers include `X-RateLimit-Remaining: 29` and `X-RateLimit-Reset: <ISO>`
- [ ] After 30 messages → 429 response includes same headers with `X-RateLimit-Remaining: 0`
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)