### PR TITLE
feat: late flag on dose logs (#174)

### DIFF
--- a/src/models/DoseLog.ts
+++ b/src/models/DoseLog.ts
@@ -6,6 +6,7 @@ export interface IDoseLog extends Document {
   supplementName: string;
   slot: string;
   takenAt: Date;
+  late?: boolean;
   createdAt: Date;
 }
 
@@ -16,6 +17,7 @@ const DoseLogSchema = new Schema<IDoseLog>(
     supplementName: { type: String, required: true },
     slot: { type: String, default: '' },
     takenAt: { type: Date, required: true },
+    late: { type: Boolean, default: false },
   },
   { timestamps: true }
 );

--- a/src/routes/schedule.ts
+++ b/src/routes/schedule.ts
@@ -14,11 +14,12 @@ router.post('/log-dose', async (req: AuthRequest, res: Response): Promise<void> 
     const userId = req.userId;
     if (!userId) { res.status(401).json({ success: false, data: null, error: 'Unauthorized' }); return; }
 
-    const { supplementId, supplementName, slot, takenAt } = req.body as {
+    const { supplementId, supplementName, slot, takenAt, late } = req.body as {
       supplementId?: unknown;
       supplementName?: unknown;
       slot?: unknown;
       takenAt?: unknown;
+      late?: unknown;
     };
 
     if (!supplementId || !Types.ObjectId.isValid(String(supplementId))) {
@@ -42,6 +43,7 @@ router.post('/log-dose', async (req: AuthRequest, res: Response): Promise<void> 
       supplementName: supplementName.trim(),
       slot: typeof slot === 'string' ? slot : '',
       takenAt: takenAtDate,
+      late: late === true,
     });
 
     res.status(201).json({ success: true, data: log, error: null });


### PR DESCRIPTION
## Summary
- `DoseLog` model: `late?: boolean` field (default false)
- `POST /schedule/log-dose`: accepts `late: true` in body to flag late dose

## Test plan
- [ ] POST with `late: true` → log stored with `late: true`
- [ ] Normal POST (no late) → `late: false`
- [ ] `npx tsc --noEmit` — zero errors
🤖 Generated with [Claude Code](https://claude.com/claude-code)