### PR TITLE
feat: effect tracking — dose-to-effect ratings and trends aggregation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import nutritionRouter from './routes/nutrition';
 import exerciseRouter from './routes/exercise';
 import adminRouter from './routes/admin';
 import { recommendationsRouter } from './routes/recommendations';
+import { effectsRouter } from './routes/effects';
 import { authenticate } from './middleware/auth';
 import { startReminderJob } from './services/reminderJob';
 
@@ -69,6 +70,7 @@ app.use('/nutrition', authenticate, nutritionRouter);
 app.use('/exercise', authenticate, exerciseRouter);
 app.use('/admin', adminRouter);
 app.use('/recommendations', recommendationsRouter);
+app.use('/effects', authenticate, effectsRouter);
 
 // Error handling
 app.use(errorHandler);

--- a/src/models/DoseEffect.ts
+++ b/src/models/DoseEffect.ts
@@ -1,0 +1,35 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IDoseEffect extends Document {
+  userId: Types.ObjectId;
+  doseLogId: Types.ObjectId;
+  supplementId: Types.ObjectId;
+  supplementName: string;
+  energy?: number;
+  focus?: number;
+  sleep?: number;
+  mood?: number;
+  ratedAt: Date;
+  createdAt: Date;
+}
+
+const DoseEffectSchema = new Schema<IDoseEffect>(
+  {
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    doseLogId: { type: Schema.Types.ObjectId, ref: 'DoseLog', required: true },
+    supplementId: { type: Schema.Types.ObjectId, ref: 'CabinetItem', required: true },
+    supplementName: { type: String, required: true },
+    energy: { type: Number, min: 1, max: 5 },
+    focus: { type: Number, min: 1, max: 5 },
+    sleep: { type: Number, min: 1, max: 5 },
+    mood: { type: Number, min: 1, max: 5 },
+    ratedAt: { type: Date, required: true, default: () => new Date() },
+  },
+  { timestamps: true }
+);
+
+DoseEffectSchema.index({ userId: 1, ratedAt: -1 });
+DoseEffectSchema.index({ userId: 1, supplementId: 1 });
+DoseEffectSchema.index({ doseLogId: 1 }, { unique: true });
+
+export const DoseEffect = model<IDoseEffect>('DoseEffect', DoseEffectSchema);

--- a/src/routes/effects.ts
+++ b/src/routes/effects.ts
@@ -1,0 +1,86 @@
+import { Router, Response } from 'express';
+import { Types } from 'mongoose';
+import { authenticate, AuthRequest } from '../middleware/auth';
+import { DoseEffect } from '../models/DoseEffect';
+
+const router = Router();
+
+interface SupplementEffectAgg {
+  name: string;
+  avgEnergy: number | null;
+  avgFocus: number | null;
+  avgSleep: number | null;
+  avgMood: number | null;
+  count: number;
+}
+
+// GET /effects?days=30
+// Returns per-supplement average effect ratings for the authenticated user over the given time window.
+// Only includes supplements with count >= 3.
+router.get('/', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = new Types.ObjectId(req.userId);
+
+    const rawDays = Number(req.query.days ?? 30);
+    const days = isNaN(rawDays) || rawDays < 1 ? 30 : Math.min(rawDays, 90);
+
+    const since = new Date();
+    since.setDate(since.getDate() - days);
+
+    const pipeline = [
+      {
+        $match: {
+          userId,
+          ratedAt: { $gte: since },
+        },
+      },
+      {
+        $group: {
+          _id: '$supplementName',
+          count: { $sum: 1 },
+          // Average only non-null values via $avg (MongoDB ignores nulls/missing fields automatically)
+          avgEnergy: { $avg: '$energy' },
+          avgFocus: { $avg: '$focus' },
+          avgSleep: { $avg: '$sleep' },
+          avgMood: { $avg: '$mood' },
+        },
+      },
+      {
+        $match: { count: { $gte: 3 } },
+      },
+      {
+        $sort: { count: -1 as const },
+      },
+    ];
+
+    const raw = await DoseEffect.aggregate<{
+      _id: string;
+      count: number;
+      avgEnergy: number | null;
+      avgFocus: number | null;
+      avgSleep: number | null;
+      avgMood: number | null;
+    }>(pipeline);
+
+    const roundOrNull = (v: number | null | undefined): number | null => {
+      if (v === null || v === undefined) return null;
+      return Math.round(v * 10) / 10;
+    };
+
+    const supplements: SupplementEffectAgg[] = raw.map((doc) => ({
+      name: doc._id,
+      avgEnergy: roundOrNull(doc.avgEnergy),
+      avgFocus: roundOrNull(doc.avgFocus),
+      avgSleep: roundOrNull(doc.avgSleep),
+      avgMood: roundOrNull(doc.avgMood),
+      count: doc.count,
+    }));
+
+    res.json({ success: true, data: { supplements }, error: null });
+  } catch (error) {
+    console.error('Effects GET error:', error);
+    res.status(500).json({ success: false, data: null, error: 'Failed to retrieve effect ratings' });
+  }
+});
+
+export { router as effectsRouter };

--- a/src/routes/intake.ts
+++ b/src/routes/intake.ts
@@ -1,6 +1,9 @@
 import { Router, Response } from 'express';
+import { Types } from 'mongoose';
 import { authenticate, AuthRequest } from '../middleware/auth';
 import { IntakeLog } from '../models/IntakeLog';
+import { DoseLog } from '../models/DoseLog';
+import { DoseEffect } from '../models/DoseEffect';
 
 const router = Router();
 
@@ -95,6 +98,77 @@ router.get('/streak', authenticate, async (req: AuthRequest, res: Response) => {
   } catch (error) {
     console.error('Intake streak GET error:', error);
     res.status(500).json({ error: 'Failed to retrieve streak data' });
+  }
+});
+
+// POST /intake/effect — rate how you felt after a dose (upsert by doseLogId)
+router.post('/effect', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
+  try {
+    const userId = new Types.ObjectId(req.userId);
+    const { doseLogId, supplementId, supplementName, energy, focus, sleep, mood } = req.body as {
+      doseLogId?: string;
+      supplementId?: string;
+      supplementName?: string;
+      energy?: unknown;
+      focus?: unknown;
+      sleep?: unknown;
+      mood?: unknown;
+    };
+
+    // Validate required fields
+    if (!doseLogId || !Types.ObjectId.isValid(doseLogId)) {
+      res.status(400).json({ success: false, data: null, error: 'doseLogId is required and must be a valid ObjectId' });
+      return;
+    }
+    if (!supplementId || !Types.ObjectId.isValid(supplementId)) {
+      res.status(400).json({ success: false, data: null, error: 'supplementId is required and must be a valid ObjectId' });
+      return;
+    }
+    if (!supplementName || typeof supplementName !== 'string' || supplementName.trim() === '') {
+      res.status(400).json({ success: false, data: null, error: 'supplementName is required' });
+      return;
+    }
+
+    // Validate that the dose log exists and belongs to this user
+    const doseLog = await DoseLog.findOne({ _id: new Types.ObjectId(doseLogId), userId }).lean();
+    if (!doseLog) {
+      res.status(404).json({ success: false, data: null, error: 'Dose log not found or does not belong to this user' });
+      return;
+    }
+
+    // Validate rating values (optional but must be 1–5 if provided)
+    const ratings: { energy?: number; focus?: number; sleep?: number; mood?: number } = {};
+    const ratingFields = { energy, focus, sleep, mood } as Record<string, unknown>;
+    for (const [field, value] of Object.entries(ratingFields)) {
+      if (value !== undefined && value !== null) {
+        const num = Number(value);
+        if (isNaN(num) || num < 1 || num > 5 || !Number.isInteger(num)) {
+          res.status(400).json({ success: false, data: null, error: `${field} must be an integer between 1 and 5` });
+          return;
+        }
+        (ratings as Record<string, number>)[field] = num;
+      }
+    }
+
+    // Upsert by doseLogId — allow re-rating the same dose
+    const effect = await DoseEffect.findOneAndUpdate(
+      { doseLogId: new Types.ObjectId(doseLogId) },
+      {
+        $set: {
+          userId,
+          supplementId: new Types.ObjectId(supplementId),
+          supplementName: supplementName.trim(),
+          ratedAt: new Date(),
+          ...ratings,
+        },
+      },
+      { upsert: true, new: true }
+    );
+
+    res.status(200).json({ success: true, data: effect, error: null });
+  } catch (error) {
+    console.error('Intake effect POST error:', error);
+    res.status(500).json({ success: false, data: null, error: 'Failed to save effect rating' });
   }
 });
 

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -10,6 +10,7 @@ import { ExerciseSession, IExerciseSession } from '../models/ExerciseSession';
 import { MealEntry, IMealEntry } from '../models/Nutrition';
 import { RateLimit } from '../models/RateLimit';
 import { DoseLog, IDoseLog } from '../models/DoseLog';
+import { DoseEffect } from '../models/DoseEffect';
 import { detectLanguage, DetectedLanguage } from '../utils/language';
 import { MODELS } from '../config/models';
 import { buildAiUsage, AiUsage } from '../utils/aiUsage';
@@ -232,6 +233,58 @@ Recent doses: ${recent.join(', ')}
 Use this to personalise advice (e.g. "I notice you usually take your supplements around ${peakLabel}").`;
 }
 
+async function buildEffectRatingsContext(userId: Types.ObjectId): Promise<string> {
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const pipeline = [
+    { $match: { userId, ratedAt: { $gte: thirtyDaysAgo } } },
+    {
+      $group: {
+        _id: '$supplementName',
+        count: { $sum: 1 },
+        avgEnergy: { $avg: '$energy' },
+        avgFocus: { $avg: '$focus' },
+        avgSleep: { $avg: '$sleep' },
+        avgMood: { $avg: '$mood' },
+      },
+    },
+    { $match: { count: { $gte: 3 } } },
+    { $sort: { count: -1 as const } },
+  ];
+
+  const raw = await DoseEffect.aggregate<{
+    _id: string;
+    count: number;
+    avgEnergy: number | null;
+    avgFocus: number | null;
+    avgSleep: number | null;
+    avgMood: number | null;
+  }>(pipeline);
+
+  if (raw.length === 0) return '';
+
+  const fmt = (v: number | null | undefined): string | null => {
+    if (v === null || v === undefined) return null;
+    return (Math.round(v * 10) / 10).toFixed(1);
+  };
+
+  const parts = raw.map((doc): string => {
+    const dims: string[] = [];
+    const energy = fmt(doc.avgEnergy);
+    const focus = fmt(doc.avgFocus);
+    const sleep = fmt(doc.avgSleep);
+    const mood = fmt(doc.avgMood);
+    if (energy !== null) dims.push(`energy=${energy}`);
+    if (focus !== null) dims.push(`focus=${focus}`);
+    if (sleep !== null) dims.push(`sleep=${sleep}`);
+    if (mood !== null) dims.push(`mood=${mood}`);
+    return `${doc._id}: ${dims.join(', ')} (${doc.count} ratings)`;
+  });
+
+  return `\nEFFECT RATINGS (last 30 days):\n${parts.join('; ')}`;
+}
+
 // --- System prompt builder ---
 function buildSystemPrompt(
   profile: IHealthProfile | null,
@@ -241,7 +294,8 @@ function buildSystemPrompt(
   sideEffects: ISideEffect[],
   exerciseSessions: IExerciseSession[],
   mealEntries: IMealEntry[],
-  doseLogs: IDoseLog[]
+  doseLogs: IDoseLog[],
+  effectRatingsContext: string
 ): string {
   const profileData = profile
     ? {
@@ -277,6 +331,7 @@ function buildSystemPrompt(
   const nutritionContext = buildNutritionContext(mealEntries);
   const stalenessContext = buildStalenessContext(profile);
   const doseTimingContext = buildDoseTimingContext(doseLogs);
+  const effectRatings = effectRatingsContext;
 
   // Time-of-day context for situational awareness
   const now = new Date();
@@ -294,7 +349,7 @@ ${JSON.stringify(profileData, null, 2)}
 
 CURRENT SUPPLEMENT & MEDICATION CABINET:
 ${JSON.stringify(cabinetData, null, 2)}
-${journalContext}${sideEffectContext}${exerciseContext}${nutritionContext}${stalenessContext}${doseTimingContext}
+${journalContext}${sideEffectContext}${exerciseContext}${nutritionContext}${stalenessContext}${doseTimingContext}${effectRatings}
 
 ${languageInstruction}
 
@@ -765,7 +820,7 @@ export async function processChat(
   fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14);
   const fourteenDaysAgoISO = fourteenDaysAgo.toISOString().slice(0, 10);
 
-  const [profile, cabinetItems, journalLogs, sideEffects, exerciseSessions, mealEntries, recentDoseLogs] = await Promise.all([
+  const [profile, cabinetItems, journalLogs, sideEffects, exerciseSessions, mealEntries, recentDoseLogs, effectRatingsContext] = await Promise.all([
     HealthProfile.findOne({ userId: userObjectId }),
     CabinetItem.find({ userId: userObjectId, active: true }),
     DailyLog.find({ userId: userObjectId, date: { $gte: sevenDaysAgoISO } }).sort({ date: -1 }).limit(7),
@@ -773,6 +828,7 @@ export async function processChat(
     ExerciseSession.find({ userId: userObjectId, date: { $gte: fourteenDaysAgoISO }, status: 'completed' }).sort({ date: -1 }).limit(20),
     MealEntry.find({ userId: userObjectId, date: { $gte: sevenDaysAgoISO } }).sort({ date: -1 }).limit(50),
     DoseLog.find({ userId: userObjectId, takenAt: { $gte: fourteenDaysAgo } }).sort({ takenAt: -1 }).limit(50).lean(),
+    buildEffectRatingsContext(userObjectId),
   ]);
 
   // For existing conversations, load them now; for new ones, defer creation until after AI succeeds
@@ -803,7 +859,7 @@ export async function processChat(
 
   // Call Gemini BEFORE creating/saving any conversation record
   // This prevents ghost conversations when the AI call fails
-  const systemPrompt = buildSystemPrompt(profile, cabinetItems, language, journalLogs, sideEffects, exerciseSessions, mealEntries, recentDoseLogs);
+  const systemPrompt = buildSystemPrompt(profile, cabinetItems, language, journalLogs, sideEffects, exerciseSessions, mealEntries, recentDoseLogs, effectRatingsContext);
 
   // Build message parts — text + optional image
   const messageParts: Array<{ text: string } | { inlineData: { data: string; mimeType: string } }> = [


### PR DESCRIPTION
## What
Adds effect tracking to the Recallth backend: users can rate how they felt (energy, focus, sleep, mood 1–5) after a supplement dose, and the Trends tab can show per-supplement average ratings.

## Why
Closes #183 (backend portion only — mobile side is a separate pending task)

## Acceptance Criteria
- [x] `DoseEffect` Mongoose model with energy/focus/sleep/mood fields (1–5 each), indexed on `userId+ratedAt` and `userId+supplementId`, unique constraint on `doseLogId`
- [x] `POST /intake/effect` — upserts an effect rating for a dose log; validates doseLogId ownership, rating range 1–5 integers
- [x] `GET /effects?days=30` — returns per-supplement averages over up to 90 days; only includes supplements with count >= 3, sorted by count desc
- [x] AI chat context updated — effect ratings (last 30 days) injected into system prompt via parallel DB query in `buildEffectRatingsContext`
- [x] `tsc --noEmit` — zero TypeScript errors
- [x] All 132 existing tests pass

## Test Plan
1. POST a DoseLog entry for a user
2. `POST /intake/effect` with `{ doseLogId, supplementId, supplementName, energy: 4, focus: 3 }` — expect 200 with saved DoseEffect
3. Re-POST same doseLogId with different ratings — expect upsert (same `_id`, updated values)
4. POST with invalid doseLogId (another user's) — expect 404
5. POST with `energy: 6` — expect 400
6. After 3+ effect entries for one supplement, `GET /effects?days=30` — expect that supplement in results with averaged ratings
7. `GET /effects?days=7` (fewer than 3 ratings in window) — expect empty supplements array