### PR TITLE
feat: streak freeze tokens (#220)

### DIFF
--- a/src/models/UserSettings.ts
+++ b/src/models/UserSettings.ts
@@ -8,6 +8,8 @@ export interface IUserSettings extends Document {
   emailDigestEnabled: boolean;
   emailDigestDay: string; // e.g. "sunday"
   communityContributeEnabled: boolean; // opt-out of contributing to community food DB
+  freezeTokens: number; // streak freeze tokens (0–2)
+  lastFreezeGrantedStreak: number; // streak length at which last token was granted (idempotency guard)
   createdAt: Date;
   updatedAt: Date;
 }
@@ -21,6 +23,8 @@ const UserSettingsSchema = new Schema<IUserSettings>(
     emailDigestEnabled: { type: Boolean, default: false },
     emailDigestDay: { type: String, default: 'sunday' },
     communityContributeEnabled: { type: Boolean, default: true },
+    freezeTokens: { type: Number, default: 0 },
+    lastFreezeGrantedStreak: { type: Number, default: 0 },
   },
   { timestamps: true },
 );

--- a/src/routes/intake.ts
+++ b/src/routes/intake.ts
@@ -4,12 +4,23 @@ import { authenticate, AuthRequest } from '../middleware/auth';
 import { IntakeLog } from '../models/IntakeLog';
 import { DoseLog } from '../models/DoseLog';
 import { DoseEffect } from '../models/DoseEffect';
+import { UserSettings } from '../models/UserSettings';
 
 const router = Router();
+
+const FREEZE_TOKEN_CAP = 2;
+const FREEZE_GRANT_INTERVAL = 14; // grant 1 token every N days of streak
 
 /** Returns today's date in YYYY-MM-DD UTC */
 function todayUTC(): string {
   return new Date().toISOString().slice(0, 10);
+}
+
+/** Returns yesterday's date in YYYY-MM-DD UTC */
+function yesterdayUTC(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
 }
 
 /** Compute currentStreak and longestStreak from a sorted (asc) list of YYYY-MM-DD date strings */
@@ -56,18 +67,45 @@ export function computeStreaks(dates: string[]): { currentStreak: number; longes
 router.post('/log', authenticate, async (req: AuthRequest, res: Response) => {
   try {
     const today = todayUTC();
+    const userId = req.userId!;
+
     await IntakeLog.findOneAndUpdate(
-      { userId: req.userId, date: today },
-      { userId: req.userId, date: today },
+      { userId, date: today },
+      { userId, date: today },
       { upsert: true, new: true },
     );
 
     // Compute streaks from all logs
-    const allLogs = await IntakeLog.find({ userId: req.userId }).sort({ date: 1 }).lean();
+    const allLogs = await IntakeLog.find({ userId }).sort({ date: 1 }).lean();
     const dates = allLogs.map((l) => l.date);
     const { currentStreak, longestStreak } = computeStreaks(dates);
 
-    res.json({ date: today, currentStreak, longestStreak });
+    // Grant freeze token at every FREEZE_GRANT_INTERVAL-day milestone (idempotent via lastFreezeGrantedStreak)
+    let freezeGranted = false;
+    let settings = await UserSettings.findOne({ userId }).lean();
+    const currentTokens = settings?.freezeTokens ?? 0;
+    const lastGrantedStreak = settings?.lastFreezeGrantedStreak ?? 0;
+
+    if (
+      currentStreak > 0 &&
+      currentStreak % FREEZE_GRANT_INTERVAL === 0 &&
+      currentStreak !== lastGrantedStreak &&
+      currentTokens < FREEZE_TOKEN_CAP
+    ) {
+      await UserSettings.findOneAndUpdate(
+        { userId },
+        {
+          $inc: { freezeTokens: 1 },
+          $set: { lastFreezeGrantedStreak: currentStreak },
+        },
+        { upsert: true },
+      );
+      freezeGranted = true;
+    }
+
+    const finalTokens = freezeGranted ? currentTokens + 1 : currentTokens;
+
+    res.json({ date: today, currentStreak, longestStreak, freezeGranted, freezeTokens: finalTokens });
   } catch (error) {
     console.error('Intake log POST error:', error);
     res.status(500).json({ error: 'Failed to log intake' });
@@ -86,18 +124,76 @@ router.get('/status', authenticate, async (req: AuthRequest, res: Response) => {
   }
 });
 
-// GET /intake/streak — return streak data
+// GET /intake/streak — return streak data including freeze token count
 router.get('/streak', authenticate, async (req: AuthRequest, res: Response) => {
   try {
-    const allLogs = await IntakeLog.find({ userId: req.userId }).sort({ date: 1 }).lean();
+    const userId = req.userId!;
+    const [allLogs, settings] = await Promise.all([
+      IntakeLog.find({ userId }).sort({ date: 1 }).lean(),
+      UserSettings.findOne({ userId }).lean(),
+    ]);
     const dates = allLogs.map((l) => l.date);
     const { currentStreak, longestStreak } = computeStreaks(dates);
     const lastLoggedDate = dates.length > 0 ? dates[dates.length - 1] : null;
 
-    res.json({ currentStreak, longestStreak, lastLoggedDate });
+    res.json({
+      currentStreak,
+      longestStreak,
+      lastLoggedDate,
+      freezeTokens: settings?.freezeTokens ?? 0,
+    });
   } catch (error) {
     console.error('Intake streak GET error:', error);
     res.status(500).json({ error: 'Failed to retrieve streak data' });
+  }
+});
+
+// POST /intake/apply-freeze — auto-consume a freeze token when yesterday was missed
+// Adds a retroactive IntakeLog for yesterday, preserving the streak.
+router.post('/apply-freeze', authenticate, async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.userId!;
+    const yesterday = yesterdayUTC();
+
+    const [settings, yesterdayLog] = await Promise.all([
+      UserSettings.findOne({ userId }).lean(),
+      IntakeLog.findOne({ userId, date: yesterday }).lean(),
+    ]);
+
+    if (!settings || (settings.freezeTokens ?? 0) <= 0) {
+      res.status(400).json({ success: false, error: 'No freeze tokens available' });
+      return;
+    }
+
+    if (yesterdayLog) {
+      // Yesterday already logged — no freeze needed
+      res.status(400).json({ success: false, error: 'Yesterday was already logged — no freeze needed' });
+      return;
+    }
+
+    // Add retroactive intake log for yesterday
+    await IntakeLog.findOneAndUpdate(
+      { userId, date: yesterday },
+      { userId, date: yesterday },
+      { upsert: true, new: true },
+    );
+
+    // Decrement token
+    await UserSettings.findOneAndUpdate(
+      { userId },
+      { $inc: { freezeTokens: -1 } },
+    );
+
+    // Recompute streak
+    const allLogs = await IntakeLog.find({ userId }).sort({ date: 1 }).lean();
+    const dates = allLogs.map((l) => l.date);
+    const { currentStreak } = computeStreaks(dates);
+    const tokensLeft = Math.max(0, (settings.freezeTokens ?? 0) - 1);
+
+    res.json({ success: true, streak: currentStreak, tokensLeft });
+  } catch (error) {
+    console.error('Intake apply-freeze POST error:', error);
+    res.status(500).json({ error: 'Failed to apply streak freeze' });
   }
 });
 


### PR DESCRIPTION
## Summary
- `UserSettings` model: added `freezeTokens` (0–2) and `lastFreezeGrantedStreak` fields
- `POST /intake/log`: now grants 1 freeze token at every 14-day streak milestone (idempotent via `lastFreezeGrantedStreak`); response includes `freezeGranted` and `freezeTokens`
- `GET /intake/streak`: now returns `freezeTokens` alongside existing fields
- `POST /intake/apply-freeze` (new): verifies yesterday has no intake log + tokens > 0; adds retroactive IntakeLog for yesterday; decrements token; returns `{ streak, tokensLeft }`

## Test plan
- [ ] `npx tsc --noEmit` — zero errors
- [ ] Log for 14 days → `POST /intake/log` returns `freezeGranted: true, freezeTokens: 1`
- [ ] Second call same day → `freezeGranted: false` (idempotent)
- [ ] Miss a day → call `POST /intake/apply-freeze` → streak preserved, token decremented
- [ ] `GET /intake/streak` → `freezeTokens` matches current value

🤖 Generated with [Claude Code](https://claude.com/claude-code)