### PR TITLE
feat(bloodwork): upgrade /ocr to multipart/form-data with multer (#293)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
+        "@types/multer": "^2.1.0",
         "@types/pdfkit": "^0.17.5",
         "bcrypt": "^6.0.0",
         "cors": "^2.8.6",
@@ -18,6 +19,7 @@
         "google-auth-library": "^10.6.2",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^9.4.1",
+        "multer": "^2.1.1",
         "node-cron": "^4.2.1",
         "pdfkit": "^0.18.0",
         "resend": "^6.12.3"
@@ -1691,7 +1693,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -1702,7 +1703,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1743,7 +1743,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1755,7 +1754,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1768,7 +1766,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -1841,6 +1838,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
@@ -1870,21 +1876,18 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1894,7 +1897,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -2385,6 +2387,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -2729,8 +2737,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2990,6 +3008,21 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -5933,6 +5966,68 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
@@ -6569,6 +6664,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6977,6 +7086,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -7485,6 +7611,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
@@ -7623,6 +7755,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/wkliwk/recallth-backend#readme",
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
+    "@types/multer": "^2.1.0",
     "@types/pdfkit": "^0.17.5",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.6",
@@ -35,6 +36,7 @@
     "google-auth-library": "^10.6.2",
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^9.4.1",
+    "multer": "^2.1.1",
     "node-cron": "^4.2.1",
     "pdfkit": "^0.18.0",
     "resend": "^6.12.3"

--- a/src/__tests__/bloodwork.ocr.test.ts
+++ b/src/__tests__/bloodwork.ocr.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for POST /bloodwork/ocr
+ *
+ * Mocks:
+ * - @google/generative-ai — controls AI responses without real API calls
+ * - jsonwebtoken — bypasses real JWT verification so auth passes
+ */
+
+import express from 'express';
+import request from 'supertest';
+import path from 'path';
+import fs from 'fs';
+
+// ── Mock Gemini AI before importing the router ────────────────────────────────
+
+const mockGenerateContent = jest.fn();
+
+jest.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
+    getGenerativeModel: jest.fn().mockReturnValue({
+      generateContent: mockGenerateContent,
+    }),
+  })),
+}));
+
+// ── Mock JWT so authenticate() always passes ──────────────────────────────────
+
+jest.mock('jsonwebtoken', () => ({
+  ...jest.requireActual<typeof import('jsonwebtoken')>('jsonwebtoken'),
+  verify: jest.fn().mockReturnValue({ userId: 'test-user-id' }),
+}));
+
+// ── Build a minimal Express app with just the bloodwork router ────────────────
+
+import { bloodworkRouter } from '../routes/bloodwork';
+
+const app = express();
+app.use(express.json());
+app.use('/bloodwork', bloodworkRouter);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Create a minimal 1×1 white JPEG buffer for testing */
+function makeTestImageBuffer(): Buffer {
+  // Minimal valid JPEG (SOI + EOI)
+  return Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49,
+    0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9]);
+}
+
+function buildGeminiResponse(text: string) {
+  return {
+    response: {
+      text: () => text,
+      usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 50 },
+    },
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /bloodwork/ocr', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Provide required env vars
+    process.env.GOOGLE_GEMINI_API_KEY = 'test-gemini-key';
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  // ── 1. Success case ─────────────────────────────────────────────────────────
+  it('returns extracted markers on success', async () => {
+    const markers = [
+      { name: 'Hemoglobin', value: 14.2, unit: 'g/dL' },
+      { name: 'Fasting Glucose', value: 5.4, unit: 'mmol/L' },
+      { name: 'TSH', value: 2.1, unit: 'mIU/L' },
+    ];
+
+    mockGenerateContent.mockResolvedValueOnce(
+      buildGeminiResponse(JSON.stringify(markers))
+    );
+
+    const res = await request(app)
+      .post('/bloodwork/ocr')
+      .set('Authorization', 'Bearer valid-token')
+      .attach('image', makeTestImageBuffer(), { filename: 'lab-report.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.markers).toHaveLength(3);
+    expect(res.body.markers[0]).toEqual({ name: 'Hemoglobin', value: 14.2, unit: 'g/dL' });
+    expect(res.body.error).toBeUndefined();
+  });
+
+  // ── 2. No image uploaded ────────────────────────────────────────────────────
+  it('returns 400 with empty markers when no image field is sent', async () => {
+    const res = await request(app)
+      .post('/bloodwork/ocr')
+      .set('Authorization', 'Bearer valid-token')
+      .set('Content-Type', 'multipart/form-data');
+
+    expect(res.status).toBe(400);
+    expect(res.body.markers).toEqual([]);
+    expect(typeof res.body.error).toBe('string');
+    // AI should NOT have been called
+    expect(mockGenerateContent).not.toHaveBeenCalled();
+  });
+
+  // ── 3. AI error — graceful fallback, never 500 ─────────────────────────────
+  it('returns empty markers with error message when AI throws, never 500', async () => {
+    mockGenerateContent.mockRejectedValueOnce(new Error('Gemini quota exceeded'));
+
+    const res = await request(app)
+      .post('/bloodwork/ocr')
+      .set('Authorization', 'Bearer valid-token')
+      .attach('image', makeTestImageBuffer(), { filename: 'lab-report.jpg', contentType: 'image/jpeg' });
+
+    // Must not be 500 — requirement: AI errors surface as graceful fallback
+    expect(res.status).toBe(200);
+    expect(res.body.markers).toEqual([]);
+    expect(res.body.error).toBe('Could not extract values');
+  });
+
+  // ── 4. Auth required — no token returns 401 ────────────────────────────────
+  it('returns 401 when no Authorization header is provided', async () => {
+    const res = await request(app)
+      .post('/bloodwork/ocr')
+      .attach('image', makeTestImageBuffer(), { filename: 'lab-report.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(401);
+    // AI should NOT have been called
+    expect(mockGenerateContent).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/bloodwork.ts
+++ b/src/routes/bloodwork.ts
@@ -1,6 +1,7 @@
-import { Router, Response } from 'express';
+import { Router, Response, Request } from 'express';
 import { Types } from 'mongoose';
 import { GoogleGenerativeAI } from '@google/generative-ai';
+import multer from 'multer';
 import { authenticate, AuthRequest } from '../middleware/auth';
 import { BloodworkEntry } from '../models/BloodworkEntry';
 import { CabinetItem } from '../models/CabinetItem';
@@ -8,6 +9,20 @@ import { HealthProfile } from '../models/HealthProfile';
 import { InsightCache } from '../models/InsightCache';
 import { MODELS } from '../config/models';
 import { buildAiUsage } from '../utils/aiUsage';
+
+// ─── Multer — memory storage, 10 MB limit, images only ───────────────────────
+const ocrUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+  fileFilter: (_req: Request, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
+    const allowed = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
+    if (allowed.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only JPEG, PNG, and WebP images are supported'));
+    }
+  },
+});
 
 const router = Router();
 
@@ -434,21 +449,42 @@ Rules:
 });
 
 // POST /bloodwork/ocr — extract bloodwork markers from a lab report image
-router.post('/ocr', authenticate, async (req: AuthRequest, res: Response): Promise<void> => {
-  try {
-    const { image, mimeType } = req.body as { image?: unknown; mimeType?: unknown };
+// Accepts multipart/form-data with field `image` (JPEG/PNG/WebP, max 10 MB)
+router.post(
+  '/ocr',
+  authenticate,
+  (req: AuthRequest, res: Response, next: (err?: unknown) => void) => {
+    ocrUpload.single('image')(req as Request, res, (err: unknown) => {
+      if (err instanceof multer.MulterError) {
+        if (err.code === 'LIMIT_FILE_SIZE') {
+          res.status(400).json({ markers: [], error: 'Image must be under 10 MB' });
+          return;
+        }
+        res.status(400).json({ markers: [], error: err.message });
+        return;
+      }
+      if (err instanceof Error) {
+        res.status(400).json({ markers: [], error: err.message });
+        return;
+      }
+      next();
+    });
+  },
+  async (req: AuthRequest, res: Response): Promise<void> => {
+    try {
+      const file = (req as AuthRequest & { file?: Express.Multer.File }).file;
 
-    if (typeof image !== 'string' || !image.trim()) {
-      res.status(400).json({ success: false, data: null, error: '`image` (base64 string) is required' });
-      return;
-    }
+      if (!file) {
+        res.status(400).json({ markers: [], error: 'No image uploaded — send a JPEG/PNG/WebP file in the `image` field' });
+        return;
+      }
 
-    const validTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
-    const resolvedMime = typeof mimeType === 'string' && validTypes.includes(mimeType) ? mimeType : 'image/jpeg';
+      const imageBase64 = file.buffer.toString('base64');
+      const mimeType = file.mimetype as 'image/jpeg' | 'image/jpg' | 'image/png' | 'image/webp';
 
-    const model = getGenAI().getGenerativeModel({ model: MODELS.CHAT });
+      const model = getGenAI().getGenerativeModel({ model: MODELS.CHAT });
 
-    const prompt = `You are a medical lab report parser. Extract all bloodwork markers from this lab report image.
+      const prompt = `Extract all blood test marker names, values, and units from this lab report. Return as JSON array: [{name, value, unit}]. Only include numeric lab values.
 
 Return ONLY a valid JSON array (no markdown fences, no explanation):
 [
@@ -459,38 +495,50 @@ Return ONLY a valid JSON array (no markdown fences, no explanation):
 Rules:
 - Include every measurable marker visible in the image (e.g. Hemoglobin, Glucose, TSH, LDL, HDL, etc.)
 - "name" should be the standard English marker name (e.g. "Hemoglobin", "Fasting Glucose", "TSH")
-- "value" must be a numeric value
+- "value" must be a numeric value (not a string, not a range)
 - "unit" should be the unit shown (e.g. "g/dL", "mmol/L", "mIU/L", "mg/dL")
 - If no markers can be read, return an empty array: []
 - Do NOT include reference ranges or flags — only name, value, unit`;
 
-    const result = await model.generateContent([
-      { text: prompt },
-      { inlineData: { data: image, mimeType: resolvedMime } },
-    ]);
+      const result = await model.generateContent([
+        { text: prompt },
+        { inlineData: { data: imageBase64, mimeType } },
+      ]);
 
-    const raw = result.response.text().trim()
-      .replace(/^```(?:json)?\s*/i, '')
-      .replace(/\s*```$/, '')
-      .trim();
+      const usage = result.response.usageMetadata;
+      console.log(
+        `[AI] model=${MODELS.CHAT} input_tokens=${usage?.promptTokenCount} output_tokens=${usage?.candidatesTokenCount} task=bloodwork-ocr`
+      );
 
-    let markers: Array<{ name: string; value: number; unit: string }> = [];
-    try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) {
-        markers = parsed.filter(
-          (m) => typeof m?.name === 'string' && typeof m?.value === 'number' && typeof m?.unit === 'string'
-        );
+      const raw = result.response.text().trim()
+        .replace(/^```(?:json)?\s*/i, '')
+        .replace(/\s*```$/, '')
+        .trim();
+
+      let markers: Array<{ name: string; value: number; unit: string }> = [];
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          markers = (parsed as unknown[]).filter(
+            (m): m is { name: string; value: number; unit: string } =>
+              typeof (m as Record<string, unknown>)?.name === 'string' &&
+              typeof (m as Record<string, unknown>)?.value === 'number' &&
+              typeof (m as Record<string, unknown>)?.unit === 'string'
+          );
+        }
+      } catch {
+        // Unparseable — return graceful fallback rather than 500
+        res.json({ markers: [], error: 'Could not extract values' });
+        return;
       }
-    } catch {
-      // Unparseable — return empty array rather than 500
-    }
 
-    res.json({ success: true, data: markers, error: null });
-  } catch (err) {
-    console.error('[POST /bloodwork/ocr]', err);
-    res.status(500).json({ success: false, data: null, error: 'OCR processing failed' });
+      res.json({ markers });
+    } catch (err) {
+      console.error('[POST /bloodwork/ocr]', err);
+      // Never surface AI errors as 500 — return graceful fallback
+      res.json({ markers: [], error: 'Could not extract values' });
+    }
   }
-});
+);
 
 export { router as bloodworkRouter };


### PR DESCRIPTION
## What
Upgrades `POST /bloodwork/ocr` from JSON base64 body to proper multipart/form-data using multer, matching the frontend's native `<input type="file">` upload pattern.

## Why
Closes #293

## Acceptance Criteria
- [x] `POST /bloodwork/ocr` accepts multipart/form-data with `image` field (JPEG/PNG/WebP)
- [x] Uses Gemini Vision to extract blood marker names, values, and units
- [x] Returns `{ markers: [{ name, value, unit }] }`
- [x] Handles unreadable images gracefully — returns `{ markers: [], error: 'Could not extract values' }` (never 500)
- [x] Auth-protected
- [x] Input size limit: 10 MB (multer `LIMIT_FILE_SIZE` returns 400 not 500)
- [x] `npx tsc --noEmit` passes — zero TypeScript errors
- [x] 4 unit tests added: success, no image, AI error fallback, auth required
- [x] 136 tests pass — no regressions

## Test Plan
```
curl -X POST https://<backend>/bloodwork/ocr \
  -H "Authorization: Bearer <jwt>" \
  -F "image=@/path/to/lab-report.jpg"
```
Expected: `{ "markers": [{ "name": "Hemoglobin", "value": 14.2, "unit": "g/dL" }, ...] }`